### PR TITLE
Run clippy on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ executable   ?=  aurae
 cargo         =  cargo
 
 compile: ## Compile for the local architecture ⚙
+	@$(cargo) clippy
 	@$(cargo) build
 
 install: ## Build and install (debug) 🎉
@@ -46,7 +47,7 @@ test: ## Run the tests
 	@$(cargo) test                # Tidy output
 	#@$(cargo) test -- --nocapture # Full output
 
-clean: cleanapi ## Clean your artifacts 🧼
+clean: ## Clean your artifacts 🧼
 	@echo "Cleaning..."
 	@cargo clean
 	@rm -rvf target/*

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -28,6 +28,8 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
+#![warn(clippy::unwrap_used)]
+
 use aurae::*;
 use rhai::{Engine, EvalAltResult, Position};
 use std::{env, fs::File, io::Read, path::Path, process::exit};
@@ -74,8 +76,9 @@ fn main() {
                 );
                 exit(1);
             }
-            Ok(f) => match f.strip_prefix(std::env::current_dir().unwrap().canonicalize().unwrap())
-            {
+            Ok(f) => match f.strip_prefix(
+                std::env::current_dir().unwrap().canonicalize().unwrap(),
+            ) {
                 Ok(f) => f.into(),
                 _ => f,
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub fn register_stdlib(mut engine: Engine) -> Engine {
         .register_fn("info", AuraeClient::info)
         .register_fn("runtime", AuraeClient::runtime);
 
-    return engine;
+    engine
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Clippy has a default configuration, so it will output warnings for more than explicitly configured. This should be overridable, but starting with the defaults seems like a good choice.