### PR TITLE
stream logs via grpc api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "crossbeam",
  "futures",
  "h2",
  "ipnetwork",
@@ -425,6 +426,54 @@ name = "crc-catalog"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0165d2900ae6778e36e80bbc4da3b5eefccee9ba939761f9c2882a5d9af3ff"
+
+[[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -1080,6 +1129,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -59,6 +59,7 @@ ipnetwork = "0.20.0"
 rtnetlink = "0.11.0"
 netlink-packet-route = "0.13.0" # Used for netlink_packet_route::rtnl::address::nlas definition
 thiserror = "1.0.37"
+crossbeam = "0.8"
 
 [build-dependencies]
 anyhow = "1.0.65"

--- a/auraed/src/bin/main.rs
+++ b/auraed/src/bin/main.rs
@@ -30,7 +30,7 @@
 
 #![warn(clippy::unwrap_used)]
 
-use auraed::*;
+use auraed::{logging::logchannel::LogChannel, *};
 use clap::Parser;
 use log::*;
 use std::path::PathBuf;
@@ -78,8 +78,12 @@ async fn daemon() -> i32 {
     // let logger_level = if matches.is_present("verbose") {
     let logger_level = if options.verbose { Level::Trace } else { Level::Info };
 
+    let log_collector = LogChannel::new("AuraeRuntime");
+    // Log Collector used to expose logs via API
+    let prod = log_collector.get_producer();
+
     // Initializes Logging and prepares system if auraed is run as pid=1
-    init::init(logger_level).await;
+    init::init(logger_level, prod).await;
 
     trace!("**Logging: Verbose Mode**");
     info!("Starting Aurae Daemon Runtime...");
@@ -89,6 +93,7 @@ async fn daemon() -> i32 {
         server_key: PathBuf::from(options.server_key),
         ca_crt: PathBuf::from(options.ca_crt),
         socket: PathBuf::from(options.socket),
+        log_collector,
     };
 
     let e = runtime.run().await;

--- a/auraed/src/init/mod.rs
+++ b/auraed/src/init/mod.rs
@@ -38,6 +38,9 @@ use crate::init::logging::LoggingError;
 use crate::init::system_runtime::{
     Pid1SystemRuntime, PidGt1SystemRuntime, SystemRuntime,
 };
+use crate::observe::LogItem;
+
+use crossbeam::channel::Sender;
 use log::Level;
 
 mod fileio;
@@ -66,13 +69,13 @@ pub(crate) enum InitError {
 }
 
 /// Run Aurae as an init pid 1 instance.
-pub async fn init(logger_level: Level) {
+pub async fn init(logger_level: Level, producer: Sender<LogItem>) {
     let res = match std::process::id() {
         0 => unreachable!(
             "process is running as PID 0, which should be impossible"
         ),
-        1 => Pid1SystemRuntime {}.init(logger_level),
-        _ => PidGt1SystemRuntime {}.init(logger_level),
+        1 => Pid1SystemRuntime {}.init(logger_level, producer),
+        _ => PidGt1SystemRuntime {}.init(logger_level, producer),
     }
     .await;
 

--- a/auraed/src/logging/logchannel.rs
+++ b/auraed/src/logging/logchannel.rs
@@ -1,0 +1,136 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+use std::time::SystemTime;
+
+use crate::observe::LogItem;
+use crossbeam::channel::{bounded, Receiver, Sender};
+use log::{error, trace};
+
+use super::get_timestamp_sec;
+
+/// Abstraction Layer for one log generating entity
+/// LogChannel provides channels between Log producers and log consumers
+#[derive(Debug)]
+pub struct LogChannel {
+    producer: Sender<LogItem>,
+    consumer: Receiver<LogItem>,
+    name: String,
+}
+
+impl LogChannel {
+    /// Constructor creating the channel for log communication
+    pub fn new(name: &str) -> LogChannel {
+        // TODO: decide for a cap. 40 is arbitrary 
+        let (producer, consumer) = bounded(40);
+        LogChannel { producer, consumer, name: name.to_string() }
+    }
+    /// Getter for producer channel
+    pub fn get_producer(&self) -> Sender<LogItem> {
+        self.producer.clone()
+    }
+
+    /// Getter for consumer channel
+    pub fn get_consumer(&self) -> Receiver<LogItem> {
+        self.consumer.clone()
+    }
+
+    /// Wrapper that sends a log line to the channel
+    pub fn log_line(producer: Sender<LogItem>, line: &str) {
+        match producer.send(LogItem {
+            channel: "unknown".to_string(),
+            line: line.to_string(),
+            // TODO: milliseconds type in protobuf requires 128bit type
+            timestamp: get_timestamp_sec(),
+        }) {
+            Ok(_) => {}
+            Err(e) => {
+                error!("Error! {:?}", e);
+            }
+        }
+    }
+
+    // Receives a message from the channel
+    // multiple consumer possible 
+    fn consume_line(consumer: Receiver<LogItem>) -> Option<LogItem> {
+        match consumer.recv() {
+            Ok(val) => {
+                return Some(val);
+            }
+            Err(e) => {
+                error!("Error: {:?}", e);
+                return None;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use log::Level;
+    use simplelog::SimpleLogger;
+
+    use super::*;
+
+    fn init_logging() {
+        let logger_simple = SimpleLogger::new(
+            Level::Trace.to_level_filter(),
+            simplelog::Config::default(),
+        );
+
+        multi_log::MultiLogger::init(vec![logger_simple], Level::Trace)
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_ringbuffer_queue() {
+        init_logging();
+        let lrb = LogChannel::new("Test");
+        let prod = lrb.get_producer();
+
+        LogChannel::log_line(prod.clone(), "hello");
+        LogChannel::log_line(prod.clone(), "aurae");
+        LogChannel::log_line(prod.clone(), "bye");
+
+        let consumer = lrb.get_consumer();
+
+        let cur_item = LogChannel::consume_line(consumer.clone());
+        assert!(cur_item.is_some());
+        assert_eq!(cur_item.unwrap().line, "hello");
+
+        let cur_item = LogChannel::consume_line(consumer.clone());
+        assert!(cur_item.is_some());
+        assert_eq!(cur_item.unwrap().line, "aurae");
+
+        let cur_item = LogChannel::consume_line(consumer.clone());
+        assert!(cur_item.is_some());
+        assert_eq!(cur_item.unwrap().line, "bye");
+    }
+}

--- a/auraed/src/logging/mod.rs
+++ b/auraed/src/logging/mod.rs
@@ -28,49 +28,21 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-syntax = "proto3";
+use std::{os::unix, time::SystemTime};
 
-package observe;
 
-option go_package = "github.com/aurae-runtime/client-go/pkg/api/v0/observe";
+/// Abstraction Layer for one log generating entity
+/// LogChannel provides channels between Log producers and log consumers
+pub mod logchannel;
 
-import "meta.proto";
+/// Implements Log trait. Used to add grpc API to log targets for rust internal logging 
+pub mod streamlogger;
 
-enum LogChannelType {
-  CHANNEL_STDOUT = 0;
-  CHANNEL_STDERR = 1;
-}
+/// Get UNIX timestamp in seconds for logging
+pub fn get_timestamp_sec() -> u64 {
+    let unix_ts = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("System Clock went backwards");
 
-service Observe {
-
-  rpc Status(StatusRequest) returns (StatusResponse) {}
-    // request log stream for aurae. everything logged via log macros in aurae (info!, error!, trace!, ... ).
-    rpc GetAuraeDaemonLogStream(GetAuraeDaemonLogStreamRequest) returns (stream LogItem) {}
-
-    // TODO: request log stream for a sub process
-    rpc GetSubProcessStream(GetSubProcessStreamRequest) returns (stream LogItem) {}
-
-}
-
-message StatusRequest {
-  meta.AuraeMeta meta = 1;
-}
-
-message StatusResponse {
-  meta.AuraeMeta meta = 1;
-}
-
-message GetAuraeDaemonLogStreamRequest {
-}
-
-// TODO: not implemented
-message GetSubProcessStreamRequest {
-  LogChannelType channel_type = 1;
-  uint64 process_id = 2;
-}
-
-message LogItem {
-  string channel = 1;
-  string line = 2;
-  uint64 timestamp = 3;
+    unix_ts.as_secs()
 }


### PR DESCRIPTION
Adds a log target `StreamLogger` in addition to sending log messages to stdout/stderr.
This way, we do not depend on redirecting stdout/stderr of auraed for logging. (Thanks @MalteJ)
_No need for crate `gag`, or to wrap auraed in a Child Process_ 

log messages are send via a channel. A grpc API endpoint subscribes to a channel if a client has requested a stream. 
 
There are still some TODOs, major one is streaming stdout/stderr from subprocesses created via the exec function. 