### PR TITLE
Add cname file for github pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-aurae.io

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+aurae.io


### PR DESCRIPTION
Added a CNAME file for github pages so deploys don't remove the custom domain name. This should fix the issue mentioned here https://github.com/aurae-runtime/aurae/issues/53

This explains why it's happening without the CNAME file: https://github.com/mkdocs/mkdocs/issues/1257