### PR TITLE
Warnings as errors

### DIFF
--- a/auraed/src/bin/main.rs
+++ b/auraed/src/bin/main.rs
@@ -29,6 +29,34 @@
 \* -------------------------------------------------------------------------- */
 
 #![warn(clippy::unwrap_used)]
+#![deny(bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        // TODO: unused,
+        // TODO: unused_allocation,
+        // TODO: unused_comparisons,
+        // TODO: unused_parens,
+        while_true
+        )]
+
+#![deny(// TODO: missing_copy_implementations,
+        // TODO: missing_debug_implementations,
+        // TODO: missing_docs,
+        // TODO: trivial_casts,
+        trivial_numeric_casts,
+        // TODO: unused_extern_crates,
+        // TODO: unused_import_braces,
+        // TODO: unused_qualifications,
+        // TODO: unused_results
+        )]
 
 use auraed::{logging::logchannel::LogChannel, *};
 use clap::Parser;

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -52,21 +52,23 @@
         patterns_in_fns_without_body,
         private_in_public,
         unconditional_recursion,
-        unused,
-        unused_allocation,
-        unused_comparisons,
-        unused_parens,
-        while_true)]
+        // TODO: unused,
+        // TODO: unused_allocation,
+        // TODO: unused_comparisons,
+        // TODO: unused_parens,
+        while_true
+        )]
 
-#![deny(missing_copy_implementations,
-        missing_debug_implementations,
-        missing_docs,
-        trivial_casts,
+#![deny(// TODO: missing_copy_implementations,
+        // TODO: missing_debug_implementations,
+        // TODO: missing_docs,
+        // TODO: trivial_casts,
         trivial_numeric_casts,
-        unused_extern_crates,
-        unused_import_braces,
-        unused_qualifications,
-        unused_results)]
+        // TODO: unused_extern_crates,
+        // TODO: unused_import_braces,
+        // TODO: unused_qualifications,
+        // TODO: unused_results
+        )]
 
 #![warn(clippy::unwrap_used)]
 #![warn(missing_docs)]

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -41,6 +41,7 @@
 //!
 //! [`The Aurae Standard Library`]: https://aurae.io/stdlib
 
+#![deny(warnings)]
 #![warn(clippy::unwrap_used)]
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_doc_code_examples)]

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -41,7 +41,33 @@
 //!
 //! [`The Aurae Standard Library`]: https://aurae.io/stdlib
 
-#![deny(warnings)]
+#![deny(bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true)]
+
+#![deny(missing_copy_implementations,
+        missing_debug_implementations,
+        missing_docs,
+        trivial_casts,
+        trivial_numeric_casts,
+        unused_extern_crates,
+        unused_import_braces,
+        unused_qualifications,
+        unused_results)]
+
 #![warn(clippy::unwrap_used)]
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_doc_code_examples)]

--- a/auraescript/src/bin/main.rs
+++ b/auraescript/src/bin/main.rs
@@ -120,7 +120,7 @@ fn main() {
         engine.set_optimization_level(rhai::OptimizationLevel::Simple);
 
         // Load builtin engine components
-        register_stdlib(&mut engine);
+        engine = register_stdlib(engine);
 
         let mut f = match File::open(&filename) {
             Err(err) => {

--- a/auraescript/src/bin/main.rs
+++ b/auraescript/src/bin/main.rs
@@ -30,6 +30,34 @@
 
 // TODO @kris-nova as we move to Deno we probably want to revist the main function
 // #![warn(clippy::unwrap_used)]
+#![deny(bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        // TODO: unused,
+        // TODO: unused_allocation,
+        // TODO: unused_comparisons,
+        // TODO: unused_parens,
+        while_true
+        )]
+
+#![deny(// TODO: missing_copy_implementations,
+        // TODO: missing_debug_implementations,
+        // TODO: missing_docs,
+        // TODO: trivial_casts,
+        trivial_numeric_casts,
+        // TODO: unused_extern_crates,
+        // TODO: unused_import_braces,
+        // TODO: unused_qualifications,
+        // TODO: unused_results
+        )]
 
 use auraescript::*;
 use rhai::{Engine, EvalAltResult, Position};
@@ -92,7 +120,7 @@ fn main() {
         engine.set_optimization_level(rhai::OptimizationLevel::Simple);
 
         // Load builtin engine components
-        engine = register_stdlib(engine);
+        register_stdlib(&mut engine);
 
         let mut f = match File::open(&filename) {
             Err(err) => {

--- a/auraescript/src/builtin/config.rs
+++ b/auraescript/src/builtin/config.rs
@@ -104,8 +104,10 @@ pub fn parse_aurae_config(path: String) -> Result<AuraeConfig> {
     let mut config_toml = String::new();
     let mut file = File::open(&path)?;
 
-    file.read_to_string(&mut config_toml)
-        .with_context(|| "could not read AuraeConfig toml")?;
+    if file.read_to_string(&mut config_toml)
+           .with_context(|| "could not read AuraeConfig toml")? == 0 {
+        return Err(anyhow!("empty config"));
+    }
 
     Ok(toml::from_str(&config_toml)?)
 }

--- a/auraescript/src/lib.rs
+++ b/auraescript/src/lib.rs
@@ -47,21 +47,23 @@
         patterns_in_fns_without_body,
         private_in_public,
         unconditional_recursion,
-        unused,
-        unused_allocation,
-        unused_comparisons,
-        unused_parens,
-        while_true)]
+        // TODO: unused,
+        // TODO: unused_allocation,
+        // TODO: unused_comparisons,
+        // TODO: unused_parens,
+        while_true
+        )]
 
-#![deny(missing_copy_implementations,
-        missing_debug_implementations,
-        missing_docs,
-        trivial_casts,
+#![deny(// TODO: missing_copy_implementations,
+        // TODO: missing_debug_implementations,
+        // TODO: missing_docs,
+        // TODO: trivial_casts,
         trivial_numeric_casts,
-        unused_extern_crates,
-        unused_import_braces,
-        unused_qualifications,
-        unused_results)]
+        // TODO: unused_extern_crates,
+        // TODO: unused_import_braces,
+        // TODO: unused_qualifications,
+        // TODO: unused_results
+        )]
 
 // The project prefers .expect("reason") instead of .unwrap() so we fail
 // on any .unwrap() statements in the code.
@@ -102,7 +104,7 @@ use crate::schedule::*;
 ///
 /// Each function in here must be heavily scrutinized as we will need to
 /// maintain some semblance of backward compatability over time.
-pub fn register_stdlib(mut engine: Engine) -> Engine {
+pub fn register_stdlib(engine: &mut Engine) -> &mut Engine {
     engine
         // about function
         //
@@ -221,9 +223,7 @@ pub fn register_stdlib(mut engine: Engine) -> Engine {
         // version function
         //
         // The Aurae version running on
-        .register_fn("version", version);
-
-    engine
+        .register_fn("version", version)
 }
 
 #[cfg(test)]

--- a/auraescript/src/lib.rs
+++ b/auraescript/src/lib.rs
@@ -36,6 +36,8 @@
 //!
 //! The AuraeScript definition lives in this crate library (lib.rs).
 
+#![deny(warnings)]
+
 // The project prefers .expect("reason") instead of .unwrap() so we fail
 // on any .unwrap() statements in the code.
 #![warn(clippy::unwrap_used)]

--- a/auraescript/src/lib.rs
+++ b/auraescript/src/lib.rs
@@ -104,7 +104,7 @@ use crate::schedule::*;
 ///
 /// Each function in here must be heavily scrutinized as we will need to
 /// maintain some semblance of backward compatability over time.
-pub fn register_stdlib(engine: &mut Engine) -> &mut Engine {
+pub fn register_stdlib(mut engine: Engine) -> Engine {
     engine
         // about function
         //
@@ -223,7 +223,9 @@ pub fn register_stdlib(engine: &mut Engine) -> &mut Engine {
         // version function
         //
         // The Aurae version running on
-        .register_fn("version", version)
+        .register_fn("version", version);
+
+    engine
 }
 
 #[cfg(test)]

--- a/auraescript/src/lib.rs
+++ b/auraescript/src/lib.rs
@@ -36,7 +36,32 @@
 //!
 //! The AuraeScript definition lives in this crate library (lib.rs).
 
-#![deny(warnings)]
+#![deny(bad_style,
+        const_err,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        private_in_public,
+        unconditional_recursion,
+        unused,
+        unused_allocation,
+        unused_comparisons,
+        unused_parens,
+        while_true)]
+
+#![deny(missing_copy_implementations,
+        missing_debug_implementations,
+        missing_docs,
+        trivial_casts,
+        trivial_numeric_casts,
+        unused_extern_crates,
+        unused_import_braces,
+        unused_qualifications,
+        unused_results)]
 
 // The project prefers .expect("reason") instead of .unwrap() so we fail
 // on any .unwrap() statements in the code.


### PR DESCRIPTION
I wanted to enable them all, but it will require some more work (so i won't mark #54 as fixed).

i also thought about creating an attribute that can be shared between the various crate roots but maybe that's overkill.  this implementation allows someone to fix one warning at a time.