### PR TITLE
Makefile lint

### DIFF
--- a/.github/workflows/build-compile-test.yml
+++ b/.github/workflows/build-compile-test.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
+      - name: Lint (make lint)
+        run: make lint
       - name: Build (make)
         run: make
       - name: Tests (make test)

--- a/.github/workflows/build-compile-test.yml
+++ b/.github/workflows/build-compile-test.yml
@@ -1,4 +1,4 @@
-name: Main Build (compile, test)
+name: Main Build (lint, compile, test)
 on:
   push:
     branches: main

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ all: compile install
 
 compile: auraescript auraed ## Compile for the local architecture ⚙
 
+lint: auraescript auraed
+	@$(cargo) clippy --all-features --all -- -D clippy::all -D warnings
+
 install: ## Build and install (debug) 🎉
 	@$(cargo) install --path ./auraescript --debug
 	@$(cargo) install --path ./auraed --debug

--- a/auraed/src/bin/main.rs
+++ b/auraed/src/bin/main.rs
@@ -29,15 +29,12 @@
 \* -------------------------------------------------------------------------- */
 
 #![warn(clippy::unwrap_used)]
-#![deny(bad_style,
-        const_err,
+#![warn(bad_style,
         dead_code,
         improper_ctypes,
         non_shorthand_field_patterns,
         no_mangle_generic_items,
-        overflowing_literals,
         path_statements,
-        patterns_in_fns_without_body,
         private_in_public,
         unconditional_recursion,
         // TODO: unused,
@@ -47,7 +44,7 @@
         while_true
         )]
 
-#![deny(// TODO: missing_copy_implementations,
+#![warn(// TODO: missing_copy_implementations,
         // TODO: missing_debug_implementations,
         // TODO: missing_docs,
         // TODO: trivial_casts,

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -40,16 +40,12 @@
 //! See [`The Aurae Standard Library`] for API reference.
 //!
 //! [`The Aurae Standard Library`]: https://aurae.io/stdlib
-
-#![deny(bad_style,
-        const_err,
+#![warn(bad_style,
         dead_code,
         improper_ctypes,
         non_shorthand_field_patterns,
         no_mangle_generic_items,
-        overflowing_literals,
         path_statements,
-        patterns_in_fns_without_body,
         private_in_public,
         unconditional_recursion,
         // TODO: unused,
@@ -59,7 +55,7 @@
         while_true
         )]
 
-#![deny(// TODO: missing_copy_implementations,
+#![warn(// TODO: missing_copy_implementations,
         // TODO: missing_debug_implementations,
         // TODO: missing_docs,
         // TODO: trivial_casts,

--- a/auraescript/src/bin/main.rs
+++ b/auraescript/src/bin/main.rs
@@ -62,6 +62,7 @@ use rhai::{Engine, EvalAltResult, Position};
 use std::{env, fs::File, io::Read, path::Path, process::exit};
 
 fn eprint_error(input: &str, mut err: EvalAltResult) {
+    #[allow(clippy::unwrap_used)]
     fn eprint_line(lines: &[&str], pos: Position, err_msg: &str) {
         let line = pos.line().expect("position");
         let line_no = format!("{line}: ");
@@ -90,7 +91,7 @@ fn eprint_error(input: &str, mut err: EvalAltResult) {
     }
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut contents = String::new();
 
     for filename in env::args().skip(1) {
@@ -104,7 +105,7 @@ fn main() {
                 exit(1);
             }
             Ok(f) => match f.strip_prefix(
-                std::env::current_dir().unwrap().canonicalize().unwrap(),
+                std::env::current_dir()?.canonicalize()?,
             ) {
                 Ok(f) => f.into(),
                 _ => f,
@@ -170,4 +171,5 @@ fn main() {
             eprint_error(contents, *err);
         }
     }
+    Ok(())
 }

--- a/auraescript/src/bin/main.rs
+++ b/auraescript/src/bin/main.rs
@@ -29,16 +29,12 @@
 \* -------------------------------------------------------------------------- */
 
 // TODO @kris-nova as we move to Deno we probably want to revist the main function
-// #![warn(clippy::unwrap_used)]
-#![deny(bad_style,
-        const_err,
+#![warn(bad_style,
         dead_code,
         improper_ctypes,
         non_shorthand_field_patterns,
         no_mangle_generic_items,
-        overflowing_literals,
         path_statements,
-        patterns_in_fns_without_body,
         private_in_public,
         unconditional_recursion,
         // TODO: unused,
@@ -48,7 +44,7 @@
         while_true
         )]
 
-#![deny(// TODO: missing_copy_implementations,
+#![warn(// TODO: missing_copy_implementations,
         // TODO: missing_debug_implementations,
         // TODO: missing_docs,
         // TODO: trivial_casts,
@@ -58,6 +54,8 @@
         // TODO: unused_qualifications,
         // TODO: unused_results
         )]
+
+#![warn(clippy::unwrap_used)]
 
 use auraescript::*;
 use rhai::{Engine, EvalAltResult, Position};

--- a/auraescript/src/lib.rs
+++ b/auraescript/src/lib.rs
@@ -35,16 +35,12 @@
 //! to express their applications.
 //!
 //! The AuraeScript definition lives in this crate library (lib.rs).
-
-#![deny(bad_style,
-        const_err,
+#![warn(bad_style,
         dead_code,
         improper_ctypes,
         non_shorthand_field_patterns,
         no_mangle_generic_items,
-        overflowing_literals,
         path_statements,
-        patterns_in_fns_without_body,
         private_in_public,
         unconditional_recursion,
         // TODO: unused,
@@ -54,7 +50,7 @@
         while_true
         )]
 
-#![deny(// TODO: missing_copy_implementations,
+#![warn(// TODO: missing_copy_implementations,
         // TODO: missing_debug_implementations,
         // TODO: missing_docs,
         // TODO: trivial_casts,


### PR DESCRIPTION
A less aggressive approach to #54 that enables a `make lint` command that is also run in the github workflows, but remains optional for local development.

Also enables (and fixes) a few non-default warnings.