### PR TITLE
Enable `unused` warning throughout

### DIFF
--- a/auraed/src/bin/main.rs
+++ b/auraed/src/bin/main.rs
@@ -37,7 +37,7 @@
         path_statements,
         private_in_public,
         unconditional_recursion,
-        // TODO: unused,
+        unused,
         // TODO: unused_allocation,
         // TODO: unused_comparisons,
         // TODO: unused_parens,

--- a/auraed/src/init/power.rs
+++ b/auraed/src/init/power.rs
@@ -32,7 +32,7 @@ use anyhow::anyhow;
 use log::{info, trace};
 use std::{fs::OpenOptions, io::Read, mem, path::Path, slice};
 
-extern crate libc;
+use ::libc;
 
 #[allow(dead_code)]
 pub(crate) fn syscall_reboot(action: i32) {

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -48,7 +48,7 @@
         path_statements,
         private_in_public,
         unconditional_recursion,
-        // TODO: unused,
+        unused,
         // TODO: unused_allocation,
         // TODO: unused_comparisons,
         // TODO: unused_parens,

--- a/auraescript/macros/src/lib.rs
+++ b/auraescript/macros/src/lib.rs
@@ -28,6 +28,32 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
+#![warn(bad_style,
+        dead_code,
+        improper_ctypes,
+        non_shorthand_field_patterns,
+        no_mangle_generic_items,
+        path_statements,
+        private_in_public,
+        unconditional_recursion,
+        unused,
+        // TODO: unused_allocation,
+        // TODO: unused_comparisons,
+        // TODO: unused_parens,
+        while_true
+        )]
+
+#![warn(// TODO: missing_copy_implementations,
+        // TODO: missing_debug_implementations,
+        // TODO: missing_docs,
+        // TODO: trivial_casts,
+        trivial_numeric_casts,
+        // TODO: unused_extern_crates,
+        // TODO: unused_import_braces,
+        // TODO: unused_qualifications,
+        // TODO: unused_results
+        )]
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};

--- a/auraescript/src/bin/main.rs
+++ b/auraescript/src/bin/main.rs
@@ -37,7 +37,7 @@
         path_statements,
         private_in_public,
         unconditional_recursion,
-        // TODO: unused,
+        unused,
         // TODO: unused_allocation,
         // TODO: unused_comparisons,
         // TODO: unused_parens,

--- a/auraescript/src/lib.rs
+++ b/auraescript/src/lib.rs
@@ -43,7 +43,7 @@
         path_statements,
         private_in_public,
         unconditional_recursion,
-        // TODO: unused,
+        unused,
         // TODO: unused_allocation,
         // TODO: unused_comparisons,
         // TODO: unused_parens,


### PR DESCRIPTION
Requires a small fix for an extern crate statement.
Also added the warning set to the auraescript/macros/src/lib.rs root.

Part of #54 