### PR TITLE
Ensure protoc-gen-doc check is only made for `make docs`

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -23,10 +23,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
           sudo apt-get install -y libdbus-1-dev pkg-config libseccomp-dev
+          mkdir src
+          cd src
           wget https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.5.1/protoc-gen-doc_1.5.1_linux_amd64.tar.gz
           tar -xzf protoc-gen-doc_1.5.1_linux_amd64.tar.gz
           chmod +x protoc-gen-doc
           cp protoc-gen-doc /usr/local/bin/protoc-gen-doc
+          cd ../
+          rm -rf src
       - name: Build documentation
         run: |
           make docs

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ docs: crate stdlibdocs ## Assemble all the /docs for the website locally.
 	cp -rv api/README.md docs/stdlib/index.md # Special copy for the main README
 
 	ifeq (, $(shell which protoc-gen-doc))
-	$(error "No protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
+		$(error "No protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
 	endif
 
 stdlibdocs: ## Generate the docs for the stdlib from the .proto files

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,10 @@ docs: crate stdlibdocs ## Assemble all the /docs for the website locally.
 	cp -rv README.md docs/index.md # Special copy for the main README
 	cp -rv api/README.md docs/stdlib/index.md # Special copy for the main README
 
-	ifeq ("$(wildcard /usr/local/bin/protoc-gen-doc)", "")
+stdlibdocs: ## Generate the docs for the stdlib from the .proto files
+	ifeq (, $(wildcard /usr/local/bin/protoc-gen-doc))
 		$(error "No /usr/local/bin/protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
 	endif
-
-stdlibdocs: ## Generate the docs for the stdlib from the .proto files
 	protoc --plugin=/usr/local/bin/protoc-gen-doc -I api/v0 --doc_out=docs/stdlib/v0 --doc_opt=markdown,index.md:Ignore* api/v0/*.proto
 
 crate: ## Build the crate (documentation)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ docs: crate stdlibdocs ## Assemble all the /docs for the website locally.
 	cp -rv README.md docs/index.md # Special copy for the main README
 	cp -rv api/README.md docs/stdlib/index.md # Special copy for the main README
 
-	ifneq ("$(wildcard /usr/local/bin/protoc-gen-doc)", "")
+	ifeq ("$(wildcard /usr/local/bin/protoc-gen-doc)", "")
 		$(error "No /usr/local/bin/protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
 	endif
 

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,14 @@ docs: crate stdlibdocs ## Assemble all the /docs for the website locally.
 	cp -rv README.md docs/index.md # Special copy for the main README
 	cp -rv api/README.md docs/stdlib/index.md # Special copy for the main README
 
-stdlibdocs: ## Generate the docs for the stdlib from the .proto files
-	ifeq (, $(wildcard /usr/local/bin/protoc-gen-doc))
-		$(error "No /usr/local/bin/protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
-	endif
+## Generate the docs for the stdlib from the .proto files
+ifeq (, $(wildcard /usr/local/bin/protoc-gen-doc))
+stdlibdocs:
+	$(error "No /usr/local/bin/protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
+else
+stdlibdocs:
 	protoc --plugin=/usr/local/bin/protoc-gen-doc -I api/v0 --doc_out=docs/stdlib/v0 --doc_opt=markdown,index.md:Ignore* api/v0/*.proto
+endif
 
 crate: ## Build the crate (documentation)
 	$(cargo) doc --no-deps

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ docs: crate stdlibdocs ## Assemble all the /docs for the website locally.
 	cp -rv README.md docs/index.md # Special copy for the main README
 	cp -rv api/README.md docs/stdlib/index.md # Special copy for the main README
 
-	ifeq (, $(shell which protoc-gen-doc))
-		$(error "No protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
+	ifneq ("$(wildcard /usr/local/bin/protoc-gen-doc)", "")
+		$(error "No /usr/local/bin/protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
 	endif
 
 stdlibdocs: ## Generate the docs for the stdlib from the .proto files

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ docs: crate stdlibdocs ## Assemble all the /docs for the website locally.
 	cp -rv README.md docs/index.md # Special copy for the main README
 	cp -rv api/README.md docs/stdlib/index.md # Special copy for the main README
 
- ifeq (, $(shell which protoc-gen-doc))
- $(error "No protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
- endif
+	ifeq (, $(shell which protoc-gen-doc))
+	$(error "No protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
+	endif
 
 stdlibdocs: ## Generate the docs for the stdlib from the .proto files
 	protoc --plugin=/usr/local/bin/protoc-gen-doc -I api/v0 --doc_out=docs/stdlib/v0 --doc_opt=markdown,index.md:Ignore* api/v0/*.proto

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,8 @@
 # Aurae
 
+![Main Build](https://github.com/aurae-runtime/aurae/actions/workflows/build-compile-test.yml/badge.svg)
+
+
 Aurae is a free and open source Rust project which houses a low level systems runtime daemon built specifically for enterprise distributed systems called `auraed`. 
 
 The `auraed` daemon can be ran as a pid 1 on a Linux kernel and manages containers, virtual machines, and spawning short-lived nested virtual instances of itself for an additional layer of isolation.


### PR DESCRIPTION
this ensures that anyone only interested in `make compile` or `make lint` isn't required to install `protoc-gen-doc`.