### PR TITLE
fix make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,15 @@ clean-certs: ## Clean the cert material
 fmt: headers ## Format the entire code base(s)
 	@./hack/code-format
 
+clean-auraescript:
+	cd auraescript && make clean 
+
+clean-auraed:
+	cd auraed && make clean
+
 .PHONY: clean
 clean: clean-certs
-	cd auraed && make clean
-	cd auraescript && make clean
-	@rm -rvf target/*
+	cargo clean
 
 headers: headers-write ## Fix headers. Run this if you want to clobber things.
 

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ fmt: headers ## Format the entire code base(s)
 
 .PHONY: clean
 clean: clean-certs
-	cd aurae && make clean
 	cd auraed && make clean
+	cd auraescript && make clean
 	@rm -rvf target/*
 
 headers: headers-write ## Fix headers. Run this if you want to clobber things.

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ clean-auraed:
 
 .PHONY: clean
 clean: clean-certs
-	cargo clean
+	@cargo clean
 
 headers: headers-write ## Fix headers. Run this if you want to clobber things.
 

--- a/auraed/Makefile
+++ b/auraed/Makefile
@@ -56,9 +56,7 @@ test: ## Run the tests
 
 clean: ## Clean your artifacts 🧼
 	@echo "Cleaning..."
-	@cargo clean
-	@rm -rvf target/*
-	@rm -rvf $(executable)
+	@cargo clean --package $(executable)
 
 include hack/hack.mk
 

--- a/auraescript/Makefile
+++ b/auraescript/Makefile
@@ -32,6 +32,7 @@ default: install
 all: install
 
 cargo         =  cargo
+executable   ?=  auraescript
 
 compile: ## Compile for the local architecture ⚙
 	@$(cargo) clippy
@@ -51,9 +52,7 @@ test: ## Run the tests
 
 clean: ## Clean your artifacts 🧼
 	@echo "Cleaning..."
-	@cargo clean
-	@rm -rvf target/*
-	@rm -rvf $(executable)
+	@cargo clean --package $(executable)
 
 .PHONY: help
 help:  ## Show help messages for make targets


### PR DESCRIPTION
## What it does ?
fixes error when running the clean target in the top level Makefile
## How it does it ?
In the top level Makefile replace `cd aurae && make clean` with `cd auraescript && make clean` 