### PR TITLE
More efficient CI

### DIFF
--- a/.github/workflows/build-compile-test.yml
+++ b/.github/workflows/build-compile-test.yml
@@ -29,9 +29,9 @@ jobs:
           tar -xzf protoc-gen-doc_1.5.1_linux_amd64.tar.gz
           chmod +x protoc-gen-doc
           cp protoc-gen-doc /usr/local/bin/protoc-gen-doc
+      - name: Build (make build)
+        run: make build
       - name: Lint (make lint)
         run: make lint
-      - name: Build (make)
-        run: make
       - name: Tests (make test)
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,13 @@ all: compile install
 
 compile: auraescript auraed ## Compile for the local architecture ⚙
 
-lint: auraescript auraed
-	@$(cargo) clippy --all-features --all -- -D clippy::all -D warnings
+prcheck: build lint test
+
+build:
+	@$(cargo) build
+
+lint:
+	@$(cargo) clippy --all-features --workspace -- -D clippy::all -D warnings
 
 install: ## Build and install (debug) 🎉
 	@$(cargo) install --path ./auraescript --debug


### PR DESCRIPTION
Attempting to speed up the GitHub checks that are run on pr's.

- Don't `cargo install` auraed or auraescript, as we don't need to do that for the checks
- Run build before lint since `cargo clippy` can leverage the output of `cargo build` seemingly better than vice versa.

Also added a `make prcheck` that runs the same checks that gh runs, for convenience.