### PR TITLE
More refactoring of init module (mainly network)

### DIFF
--- a/auraed/src/init/fs.rs
+++ b/auraed/src/init/fs.rs
@@ -1,55 +1,30 @@
 use log::{error, info};
-use std::ffi::{CString, NulError};
+use std::ffi::{CStr, CString};
 use std::ptr;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum FsError {
-    #[error("{source_name} cannot be converted to a CString")]
-    InvalidSourceName { source_name: String, source: NulError },
-    #[error("{target_name} cannot be converted to a CString")]
-    InvalidTargetName { target_name: String, source: NulError },
-    #[error("{fstype} cannot be converted to a CString")]
-    InvalidFstype { fstype: String, source: NulError },
     #[error("Failed to mount: source_name={source_name}, target_name={target_name}, fstype={fstype}")]
     MountFailure { source_name: String, target_name: String, fstype: String },
 }
 
 pub(crate) fn mount_vfs(
-    source_name: &str,
-    target_name: &str,
-    fstype: &str,
+    source_name: &CStr,
+    target_name: &CStr,
+    fstype: &CStr,
 ) -> Result<(), FsError> {
-    info!("Mounting {}", target_name);
-
-    // CString constructor ensures the trailing 0byte, which is required by libc::mount
-    let src_c_str =
-        CString::new(source_name).map_err(|e| FsError::InvalidSourceName {
-            source_name: source_name.to_owned(),
-            source: e,
-        })?;
-
-    let target_name_c_str =
-        CString::new(target_name).map_err(|e| FsError::InvalidTargetName {
-            target_name: target_name.to_owned(),
-            source: e,
-        })?;
+    info!("Mounting {:?}", target_name);
 
     let ret = {
         #[cfg(not(target_os = "macos"))]
-        {
-            let fstype_c_str = CString::new(fstype).map_err(|e| {
-                FsError::InvalidFstype { fstype: fstype.to_owned(), source: e }
-            })?;
-
-            unsafe {
-                libc::mount(
-                    src_c_str.as_ptr(),
-                    target_name_c_str.as_ptr(),
-                    fstype_c_str.as_ptr(),
-                    0,
-                    ptr::null(),
-                )
-            }
+        unsafe {
+            libc::mount(
+                source_name.as_ptr(),
+                target_name.as_ptr(),
+                fstype.as_ptr(),
+                0,
+                ptr::null(),
+            )
         }
 
         #[cfg(target_os = "macos")]
@@ -71,9 +46,9 @@ pub(crate) fn mount_vfs(
         };
 
         Err(FsError::MountFailure {
-            source_name: source_name.to_owned(),
-            target_name: target_name.to_owned(),
-            fstype: fstype.to_owned(),
+            source_name: source_name.to_string_lossy().to_string(),
+            target_name: target_name.to_string_lossy().to_string(),
+            fstype: fstype.to_string_lossy().to_string(),
         })
     } else {
         Ok(())

--- a/auraed/src/init/mod.rs
+++ b/auraed/src/init/mod.rs
@@ -33,13 +33,13 @@
 //! The Aurae daemon assumes that if the current process id (PID) is 1 to
 //! run itself as an initialization program, otherwise bypass the init module.
 
-use crate::init::fs::FsError;
-use crate::init::logging::LoggingError;
-use crate::init::system_runtime::{
-    Pid1SystemRuntime, PidGt1SystemRuntime, SystemRuntime,
+use crate::init::{
+    fs::FsError,
+    logging::LoggingError,
+    network::NetworkError,
+    system_runtime::{Pid1SystemRuntime, PidGt1SystemRuntime, SystemRuntime},
 };
 use crate::observe::LogItem;
-
 use crossbeam::channel::Sender;
 use log::Level;
 
@@ -66,6 +66,8 @@ pub(crate) enum InitError {
     Logging(#[from] LoggingError),
     #[error(transparent)]
     Fs(#[from] FsError),
+    #[error(transparent)]
+    Network(#[from] NetworkError),
 }
 
 /// Run Aurae as an init pid 1 instance.

--- a/auraed/src/init/system_runtime.rs
+++ b/auraed/src/init/system_runtime.rs
@@ -1,31 +1,10 @@
-use crate::init::network::{
-    add_address, add_route_v6, set_link_up, show_network_info,
-};
 use crate::init::power::spawn_thread_power_button_listener;
-use crate::init::{fs, logging, InitError, BANNER};
+use crate::init::{fs, logging, network, InitError, BANNER};
 use crate::observe::LogItem;
-
-use anyhow::anyhow;
 use crossbeam::channel::Sender;
-use ipnetwork::{IpNetwork, Ipv6Network};
 use log::{error, info, trace, Level};
-use netlink_packet_route::RtnlMessage;
-use rtnetlink::new_connection;
-use rtnetlink::proto::Connection;
 use std::path::Path;
 use tonic::async_trait;
-
-const LOOPBACK_DEV: &str = "lo";
-
-const LOOPBACK_IPV6: &str = "::1";
-const LOOPBACK_IPV6_SUBNET: &str = "/128";
-
-const LOOPBACK_IPV4: &str = "127.0.0.1";
-const LOOPBACK_IPV4_SUBNET: &str = "/8";
-
-const DEFAULT_NET_DEV: &str = "eth0";
-const DEFAULT_NET_DEV_IPV6: &str = "fe80::2";
-const DEFAULT_NET_DEV_IPV6_SUBNET: &str = "/64";
 
 const POWER_BUTTON_DEVICE: &str = "/dev/input/event0";
 
@@ -41,112 +20,6 @@ pub(crate) trait SystemRuntime {
 pub(crate) struct Pid1SystemRuntime;
 
 impl Pid1SystemRuntime {
-    async fn init_network(
-        &self,
-        connection: Connection<RtnlMessage>,
-        handle: &rtnetlink::Handle,
-    ) {
-        tokio::spawn(connection);
-
-        trace!("configure {}", LOOPBACK_DEV);
-        match self.configure_loopback(handle).await {
-            Ok(_) => {
-                info!("Successfully configured {}", LOOPBACK_DEV);
-            }
-            Err(e) => {
-                error!("Failed to setup loopback device. Error={}", e);
-            }
-        }
-
-        trace!("configure {}", DEFAULT_NET_DEV);
-
-        match self.configure_nic(handle).await {
-            Ok(_) => {
-                info!("Successfully configured {}", DEFAULT_NET_DEV);
-            }
-            Err(e) => {
-                error!(
-                    "Failed to configure NIC {}. Error={}",
-                    DEFAULT_NET_DEV, e
-                );
-            }
-        }
-
-        show_network_info(handle).await;
-    }
-
-    async fn configure_loopback(
-        &self,
-        handle: &rtnetlink::Handle,
-    ) -> anyhow::Result<()> {
-        if let Ok(ipv6) = format!("{}{}", LOOPBACK_IPV6, LOOPBACK_IPV6_SUBNET)
-            .parse::<IpNetwork>()
-        {
-            if let Err(e) = add_address(LOOPBACK_DEV, ipv6, handle).await {
-                return Err(anyhow!("Failed to add ipv6 address to loopback device {}. Error={}", LOOPBACK_DEV, e));
-            };
-        }
-
-        if let Ok(ipv4) = format!("{}{}", LOOPBACK_IPV4, LOOPBACK_IPV4_SUBNET)
-            .parse::<IpNetwork>()
-        {
-            if let Err(e) = add_address(LOOPBACK_DEV, ipv4, handle).await {
-                return Err(anyhow!("Failed to add ipv4 address to loopback device {}. Error={}", LOOPBACK_DEV, e));
-            }
-        };
-
-        if let Err(e) = set_link_up(handle, LOOPBACK_DEV).await {
-            return Err(anyhow!(
-                "Failed to set link up for device {}. Error={}",
-                LOOPBACK_DEV,
-                e
-            ));
-        }
-
-        Ok(())
-    }
-
-    // TODO: design network config struct
-    async fn configure_nic(
-        &self,
-        handle: &rtnetlink::Handle,
-    ) -> anyhow::Result<()> {
-        if let Ok(ipv6) =
-            format!("{}{}", DEFAULT_NET_DEV_IPV6, DEFAULT_NET_DEV_IPV6_SUBNET)
-                .parse::<Ipv6Network>()
-        {
-            if let Err(e) = add_address(DEFAULT_NET_DEV, ipv6, handle).await {
-                return Err(anyhow!(
-                    "Failed to add ipv6 address to device {}. Error={}",
-                    DEFAULT_NET_DEV,
-                    e
-                ));
-            }
-
-            if let Err(e) = set_link_up(handle, DEFAULT_NET_DEV).await {
-                return Err(anyhow!(
-                    "Failed to set link up for device {}. Error={}",
-                    DEFAULT_NET_DEV,
-                    e
-                ));
-            }
-
-            if let Ok(destv6) = "::/0".to_string().parse::<Ipv6Network>() {
-                if let Err(e) =
-                    add_route_v6(&destv6, DEFAULT_NET_DEV, &ipv6, handle).await
-                {
-                    return Err(anyhow!(
-                        "Failed to add ipv6 route to device {}. Error={}",
-                        DEFAULT_NET_DEV,
-                        e
-                    ));
-                }
-            }
-        };
-
-        Ok(())
-    }
-
     fn spawn_system_runtime_threads(&self) {
         // ---- MAIN DAEMON THREAD POOL ----
         // TODO: https://github.com/aurae-runtime/auraed/issues/33
@@ -186,14 +59,9 @@ impl SystemRuntime for Pid1SystemRuntime {
 
         trace!("configure network");
         //show_dir("/sys/class/net/", false); // Show available network interfaces
-        match new_connection() {
-            Ok((connection, handle, ..)) => {
-                self.init_network(connection, &handle).await;
-            }
-            Err(e) => {
-                error!("Could not initialize network! Error={}", e);
-            }
-        };
+        let network = network::Network::connect()?;
+        network.init().await?;
+        network.show_network_info().await;
 
         self.spawn_system_runtime_threads();
 

--- a/auraed/src/init/system_runtime.rs
+++ b/auraed/src/init/system_runtime.rs
@@ -3,6 +3,7 @@ use crate::init::{fs, logging, network, InitError, BANNER};
 use crate::observe::LogItem;
 use crossbeam::channel::Sender;
 use log::{error, info, trace, Level};
+use std::ffi::CString;
 use std::path::Path;
 use tonic::async_trait;
 
@@ -53,9 +54,21 @@ impl SystemRuntime for Pid1SystemRuntime {
         trace!("Logging started");
 
         trace!("Configure filesystem");
-        fs::mount_vfs("none", "/dev", "devtmpfs")?;
-        fs::mount_vfs("none", "/sys", "sysfs")?;
-        fs::mount_vfs("proc", "/proc", "proc")?;
+        fs::mount_vfs(
+            &CString::new("none").expect("valid CString"),
+            &CString::new("/dev").expect("valid CString"),
+            &CString::new("devtmpfs").expect("valid CString"),
+        )?;
+        fs::mount_vfs(
+            &CString::new("none").expect("valid CString"),
+            &CString::new("/sys").expect("valid CString"),
+            &CString::new("sysfs").expect("valid CString"),
+        )?;
+        fs::mount_vfs(
+            &CString::new("proc").expect("valid CString"),
+            &CString::new("/proc").expect("valid CString"),
+            &CString::new("proc").expect("valid CString"),
+        )?;
 
         trace!("configure network");
         //show_dir("/sys/class/net/", false); // Show available network interfaces


### PR DESCRIPTION
Refactored the network code to better contain it in its own module. 

Also eliminated some errors from `init/fs`, as we currently control the input and can use `expect` instead.

Note: Network can probably be improved if the link indexes are stable across calls, but I didn't know if that is true, so did not make that assumption.