### PR TITLE
fix: remove typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ if execute {
 }
 ```
 
-AuraeScript servers as one of many clients to the system and can be used to express workload manifests instead of YAML.
+AuraeScript serves as one of many clients to the system and can be used to express workload manifests instead of YAML.
 AuraeScript can be used to control and gain visibility to the system.
 
 ## The Aurae Standard Library


### PR DESCRIPTION
This change removes a small typo in the README (servers -> serves).