### PR TITLE
enable the trivial casts lint warning

### DIFF
--- a/auraed/src/bin/main.rs
+++ b/auraed/src/bin/main.rs
@@ -46,7 +46,7 @@
 #![warn(// TODO: missing_copy_implementations,
         // TODO: missing_debug_implementations,
         // TODO: missing_docs,
-        // TODO: trivial_casts,
+        trivial_casts,
         trivial_numeric_casts,
         // TODO: unused_extern_crates,
         // TODO: unused_import_braces,

--- a/auraed/src/init/power.rs
+++ b/auraed/src/init/power.rs
@@ -63,6 +63,10 @@ pub(crate) struct InputEvent {
 // see  https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/input-event-codes.h#L191
 const KEY_POWER: u16 = 116;
 
+fn to_u8_ptr<T>(p: *mut T) -> *mut u8 {
+    p as _
+}
+
 pub(crate) fn spawn_thread_power_button_listener(
     power_btn_device_path: impl AsRef<Path>,
 ) -> anyhow::Result<()> {
@@ -88,10 +92,7 @@ pub(crate) fn spawn_thread_power_button_listener(
     std::thread::spawn(move || {
         loop {
             let event_slice = unsafe {
-                slice::from_raw_parts_mut(
-                    &mut event as *mut _ as *mut u8,
-                    event_size,
-                )
+                slice::from_raw_parts_mut(to_u8_ptr(&mut event), event_size)
             };
             match event_file.read(event_slice) {
                 Ok(result) => {

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -57,7 +57,7 @@
 #![warn(// TODO: missing_copy_implementations,
         // TODO: missing_debug_implementations,
         // TODO: missing_docs,
-        // TODO: trivial_casts,
+        trivial_casts,
         trivial_numeric_casts,
         // TODO: unused_extern_crates,
         // TODO: unused_import_braces,

--- a/auraed/src/logging/logchannel.rs
+++ b/auraed/src/logging/logchannel.rs
@@ -99,7 +99,7 @@ mod tests {
         );
 
         multi_log::MultiLogger::init(vec![logger_simple], Level::Trace)
-            .unwrap();
+            .expect("failed to initialize logger");
     }
 
     #[tokio::test]

--- a/auraescript/macros/src/lib.rs
+++ b/auraescript/macros/src/lib.rs
@@ -42,11 +42,10 @@
         // TODO: unused_parens,
         while_true
         )]
-
 #![warn(// TODO: missing_copy_implementations,
         // TODO: missing_debug_implementations,
         // TODO: missing_docs,
-        // TODO: trivial_casts,
+        trivial_casts,
         trivial_numeric_casts,
         // TODO: unused_extern_crates,
         // TODO: unused_import_braces,
@@ -58,8 +57,8 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
-mod get_set;
 mod client;
+mod get_set;
 
 /// Outputs the macro content during a render.
 #[proc_macro_derive(Output)]

--- a/auraescript/src/bin/main.rs
+++ b/auraescript/src/bin/main.rs
@@ -43,18 +43,16 @@
         // TODO: unused_parens,
         while_true
         )]
-
 #![warn(// TODO: missing_copy_implementations,
         // TODO: missing_debug_implementations,
         // TODO: missing_docs,
-        // TODO: trivial_casts,
+        trivial_casts,
         trivial_numeric_casts,
         // TODO: unused_extern_crates,
         // TODO: unused_import_braces,
         // TODO: unused_qualifications,
         // TODO: unused_results
         )]
-
 #![warn(clippy::unwrap_used)]
 
 use auraescript::*;
@@ -104,12 +102,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 );
                 exit(1);
             }
-            Ok(f) => match f.strip_prefix(
-                std::env::current_dir()?.canonicalize()?,
-            ) {
-                Ok(f) => f.into(),
-                _ => f,
-            },
+            Ok(f) => {
+                match f.strip_prefix(std::env::current_dir()?.canonicalize()?) {
+                    Ok(f) => f.into(),
+                    _ => f,
+                }
+            }
         };
 
         // Initialize scripting engine

--- a/auraescript/src/lib.rs
+++ b/auraescript/src/lib.rs
@@ -52,7 +52,7 @@
 #![warn(// TODO: missing_copy_implementations,
         // TODO: missing_debug_implementations,
         // TODO: missing_docs,
-        // TODO: trivial_casts,
+        trivial_casts,
         trivial_numeric_casts,
         // TODO: unused_extern_crates,
         // TODO: unused_import_braces,


### PR DESCRIPTION
this one required some work to avoid a cast and use coercion instead

i also fixed a use of unwrap. i know it's ok to use in tests, but clippy was yelling at me.