### PR TITLE
Set edit uri for main branch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: "Aurae Runtime"
 site_url: "https://aurae.io"
 repo_url: "https://github.com/aurae-runtime/aurae"
+edit_uri: "edit/main/"
 
 nav:
   - Home: index.md


### PR DESCRIPTION
This does not default to branch main according to the mkdoc docs [1]. Set it based on the documented GitHub default, swapped for main.

[1] https://www.mkdocs.org/user-guide/configuration/