### PR TITLE
remove TODO for `missing_copy_implementation`

### DIFF
--- a/auraed/src/bin/main.rs
+++ b/auraed/src/bin/main.rs
@@ -39,8 +39,7 @@
     unused_comparisons,
     while_true
 )]
-#![warn(// TODO: missing_copy_implementations,
-        // TODO: missing_debug_implementations,
+#![warn(// TODO: missing_debug_implementations,
         // TODO: missing_docs,
         trivial_casts,
         trivial_numeric_casts,

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -50,8 +50,7 @@
     unused_comparisons,
     while_true
 )]
-#![warn(// TODO: missing_copy_implementations,
-        // TODO: missing_debug_implementations,
+#![warn(// TODO: missing_debug_implementations,
         // TODO: missing_docs,
         trivial_casts,
         trivial_numeric_casts,

--- a/auraescript/macros/src/lib.rs
+++ b/auraescript/macros/src/lib.rs
@@ -41,8 +41,7 @@
     unused_comparisons,
     while_true
 )]
-#![warn(// TODO: missing_copy_implementations,
-        // TODO: missing_debug_implementations,
+#![warn(// TODO: missing_debug_implementations,
         // TODO: missing_docs,
         trivial_casts,
         trivial_numeric_casts,

--- a/auraescript/src/bin/main.rs
+++ b/auraescript/src/bin/main.rs
@@ -39,8 +39,7 @@
     unused_comparisons,
     while_true
 )]
-#![warn(// TODO: missing_copy_implementations,
-        // TODO: missing_debug_implementations,
+#![warn(// TODO: missing_debug_implementations,
         // TODO: missing_docs,
         trivial_casts,
         trivial_numeric_casts,

--- a/auraescript/src/lib.rs
+++ b/auraescript/src/lib.rs
@@ -45,8 +45,7 @@
     unused_comparisons,
     while_true
 )]
-#![warn(// TODO: missing_copy_implementations,
-        // TODO: missing_debug_implementations,
+#![warn(// TODO: missing_debug_implementations,
         // TODO: missing_docs,
         trivial_casts,
         trivial_numeric_casts,


### PR DESCRIPTION
we shouldn't be requiring copy implementations.  if we do, it's only a matter of time before someone accidentally copies a large data structure causing performance or memory issues that will take forever to track down.

Copy should be an intentional trait to support.