### PR TITLE
Add libseccomp-dev and libdbus-1-dev to build container

### DIFF
--- a/auraed/hack/build-container/Dockerfile
+++ b/auraed/hack/build-container/Dockerfile
@@ -35,7 +35,9 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     gperf \
     ninja-build \
     protobuf-compiler \
-    libprotobuf-dev
+    libprotobuf-dev \
+    libdbus-1-dev \
+    libseccomp-dev
 
 RUN rustup component add clippy
 RUN mkdir /aurae


### PR DESCRIPTION
During the setup of qemu vm for auraed I run into the issue that these dependencies are missing inside the build-container.

#### ```make initramfs``` fails with:

```
   --- stderr
  pkg_config failed: `"pkg-config" "--libs" "--cflags" "dbus-1" "dbus-1 >= 1.6"` did not exit successfully: exit status: 1
  error: could not find system library 'dbus-1' required by the 'libdbus-sys' crate

  --- stderr
  Package dbus-1 was not found in the pkg-config search path.
  Perhaps you should add the directory containing `dbus-1.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'dbus-1' found
  Package dbus-1 was not found in the pkg-config search path.
  Perhaps you should add the directory containing `dbus-1.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'dbus-1' found

  One possible solution is to check whether packages
  'libdbus-1-dev' and 'pkg-config' are installed:
  On Ubuntu:
  sudo apt install libdbus-1-dev pkg-config
  On Fedora:
  sudo dnf install dbus-devel pkgconf-pkg-config

  thread 'main' panicked at 'explicit panic', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libdbus-sys-0.2.2/build.rs:16:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
````

```
  --- stderr
  `"pkg-config" "--libs" "--cflags" "libseccomp" "libseccomp >= 2.5"` did not exit successfully: exit status: 1
  error: could not find system library 'libseccomp' required by the 'libseccomp' crate

  --- stderr
  Package libseccomp was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libseccomp.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'libseccomp' found
  Package libseccomp was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libseccomp.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'libseccomp' found
```