### PR TITLE
add missing dependencies to build doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea*
 target*
 docs/crate/*
+pki/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .idea*
 target*
 docs/crate/*
-pki/*

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Aurae brings [SPIFFE](https://github.com/spiffe)/[SPIRE](https://github.com/spif
 
 ### Standard Library
 
-Aurae exposes its functionality over a gRPC API which is referred to as the [Aurae Standard Library](https://github.com/aurae-runtime/auraed/tree/main/stdlib#the-aurae-standard-library).
+Aurae exposes its functionality over a gRPC API which is referred to as the [Aurae Standard Library](https://aurae.io/stdlib/).
 
 ### Principle of Least Awareness
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -13,16 +13,18 @@ https://github.com/aurae-runtime/aurae.git
 The Aurae environment depends on the `protoc` protocol buffer compiler being available within the path.
 Install `protoc` using your operating system's package manager (Or from source if you want to :) )
 
+A few crates are dependent on system libraries such as D-Bus for systemd and seccomp.
+
 ##### Ubuntu 
 
 ```bash
-sudo apt install -y protobuf-compiler
+sudo apt install -y protobuf-compiler pkg-config libdbus-1-dev libseccomp-dev
 ```
 
 ##### Arch Linux
 
 ```bash 
-pacman -S protobuf
+pacman -S protobuf pkgconf dbus libseccomp
 ```
 
 ### Prepare the Environment


### PR DESCRIPTION
Hi! I'm brand new to the project and was running through [building from source doc](https://aurae.io/build/). Found a couple missing system dependencies that a few crates depend on. 

* `pkg-config` 
* `libdbus-1-dev`
* `libseccomp-dev`

I'm building on Ubuntu 22.04 jammy with a fresh Rust 1.65 install. Once installing those dependencies via `apt`, I was able to build both auraed and auraescript without issue.

I also updated the link to the aurae.io site for the standard library since it was linking to the (now archived?) [auraed stdlib README](https://github.com/aurae-runtime/auraed/blob/main/stdlib/README.md). If that should be reverted and remain linking to the original source, let me know! As far as I read through, the content looked to be the same and I assumed that the doc site will be the authoritative reference for the stdlib going forward.

Log snippets from Make before adding those deps:

```shell
error: failed to run custom build command for `libdbus-sys v0.2.2`
...
  --- stderr
  pkg_config failed: Could not run `"pkg-config" "--libs" "--cflags" "dbus-1" "dbus-1 >= 1.6"`
  The pkg-config command could not be found.

error: failed to run custom build command for `libdbus-sys v0.2.2`
...
  --- stderr
  pkg_config failed: `"pkg-config" "--libs" "--cflags" "dbus-1" "dbus-1 >= 1.6"` did not exit successfully: exit status: 1
  error: could not find system library 'dbus-1' required by the 'libdbus-sys' crate

  --- stderr
  Package dbus-1 was not found in the pkg-config search path.
  Perhaps you should add the directory containing `dbus-1.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'dbus-1' found

error: failed to run custom build command for `libseccomp v0.0.2 (https://github.com/containers/youki.git?tag=v0.0.2#0f662dd9)`
...
  --- stderr
  `"pkg-config" "--libs" "--cflags" "libseccomp" "libseccomp >= 2.5"` did not exit successfully: exit status: 1
  error: could not find system library 'libseccomp' required by the 'libseccomp' crate
```