### PR TITLE
enable unused_results

### DIFF
--- a/auraed/src/bin/main.rs
+++ b/auraed/src/bin/main.rs
@@ -46,7 +46,7 @@
         unused_extern_crates,
         unused_import_braces,
         unused_qualifications,
-        // TODO: unused_results
+        unused_results
         )]
 
 use auraed::{logging::logchannel::LogChannel, *};

--- a/auraed/src/init/network/mod.rs
+++ b/auraed/src/init/network/mod.rs
@@ -73,7 +73,7 @@ pub(crate) struct Network(Handle);
 impl Network {
     pub(crate) fn connect() -> Result<Network, NetworkError> {
         let (connection, handle, _) = rtnetlink::new_connection()?;
-        let _unused_join_handle = tokio::spawn(connection);
+        let _ = tokio::spawn(connection);
         Ok(Self(handle))
     }
 
@@ -319,7 +319,7 @@ async fn get_links(
     'outer: while let Some(link_msg) = links.try_next().await? {
         for nla in link_msg.nlas.into_iter() {
             if let Nla::IfName(name) = nla {
-                let _unused_result = result.insert(link_msg.header.index, name);
+                let _ = result.insert(link_msg.header.index, name);
                 continue 'outer;
             }
         }

--- a/auraed/src/init/network/mod.rs
+++ b/auraed/src/init/network/mod.rs
@@ -73,7 +73,7 @@ pub(crate) struct Network(Handle);
 impl Network {
     pub(crate) fn connect() -> Result<Network, NetworkError> {
         let (connection, handle, _) = rtnetlink::new_connection()?;
-        tokio::spawn(connection);
+        let _unused_join_handle = tokio::spawn(connection);
         Ok(Self(handle))
     }
 
@@ -319,7 +319,7 @@ async fn get_links(
     'outer: while let Some(link_msg) = links.try_next().await? {
         for nla in link_msg.nlas.into_iter() {
             if let Nla::IfName(name) = nla {
-                result.insert(link_msg.header.index, name);
+                let _unused_result = result.insert(link_msg.header.index, name);
                 continue 'outer;
             }
         }

--- a/auraed/src/init/power.rs
+++ b/auraed/src/init/power.rs
@@ -37,7 +37,9 @@ use ::libc;
 #[allow(dead_code)]
 pub(crate) fn syscall_reboot(action: i32) {
     unsafe {
-        libc::reboot(action);
+        if libc::reboot(action) != 0 {
+            panic!("failed to reboot");
+        }
     }
 }
 
@@ -89,7 +91,7 @@ pub(crate) fn spawn_thread_power_button_listener(
     let event_size = mem::size_of::<InputEvent>();
 
     let power_btn_device = power_btn_device_path.as_ref().to_owned();
-    std::thread::spawn(move || {
+    let _unused_join_handle = std::thread::spawn(move || {
         loop {
             let event_slice = unsafe {
                 slice::from_raw_parts_mut(to_u8_ptr(&mut event), event_size)

--- a/auraed/src/init/power.rs
+++ b/auraed/src/init/power.rs
@@ -38,6 +38,7 @@ use ::libc;
 pub(crate) fn syscall_reboot(action: i32) {
     unsafe {
         if libc::reboot(action) != 0 {
+            // TODO: handle this better
             panic!("failed to reboot");
         }
     }
@@ -91,7 +92,7 @@ pub(crate) fn spawn_thread_power_button_listener(
     let event_size = mem::size_of::<InputEvent>();
 
     let power_btn_device = power_btn_device_path.as_ref().to_owned();
-    let _unused_join_handle = std::thread::spawn(move || {
+    let _ = std::thread::spawn(move || {
         loop {
             let event_slice = unsafe {
                 slice::from_raw_parts_mut(to_u8_ptr(&mut event), event_size)

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -191,14 +191,15 @@ impl AuraedRuntime {
 
         let mut opt =
             ConnectOptions::new("sqlite:/var/lib/aurae.db".to_owned());
-        let _unused_opt = opt.sqlx_logging(false).sqlcipher_key(Cow::from(
-            format!("{:?}", db_key.to_ascii_lowercase()),
-        ));
+        let _ = opt.sqlx_logging(false).sqlcipher_key(Cow::from(format!(
+            "{:?}",
+            db_key.to_ascii_lowercase()
+        )));
 
         // Pragma initial connection
         // TODO add sqlcipher_key
         let mut opt = ConnectOptions::new("sqlite::memory:".to_owned());
-        let _unused_opt = opt.sqlx_logging(false);
+        let _ = opt.sqlx_logging(false);
         let db = Database::connect(opt).await?;
         let x = db
             .execute(Statement::from_string(
@@ -227,7 +228,7 @@ fn command_from_string(cmd: &str) -> Result<Command, anyhow::Error> {
     let mut command = Command::new(base);
     for ent in entries {
         if ent != base {
-            let _unused_command = command.arg(ent);
+            let _ = command.arg(ent);
         }
     }
     Ok(command)

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -56,7 +56,7 @@
         trivial_numeric_casts,
         unused_extern_crates,
         unused_import_braces,
-        // TODO: unused_results
+        unused_results
         )]
 #![warn(clippy::unwrap_used)]
 #![warn(missing_docs)]
@@ -188,16 +188,17 @@ impl AuraedRuntime {
         // SQLite
         info!("Database Location:  /var/lib/aurae.db");
         info!("Unlocking SQLite Database with Key: {:?}", self.server_key);
+
         let mut opt =
             ConnectOptions::new("sqlite:/var/lib/aurae.db".to_owned());
-        opt.sqlx_logging(false).sqlcipher_key(Cow::from(format!(
-            "{:?}",
-            db_key.to_ascii_lowercase()
-        )));
+        let _unused_opt = opt.sqlx_logging(false).sqlcipher_key(Cow::from(
+            format!("{:?}", db_key.to_ascii_lowercase()),
+        ));
 
         // Pragma initial connection
+        // TODO add sqlcipher_key
         let mut opt = ConnectOptions::new("sqlite::memory:".to_owned());
-        opt.sqlx_logging(false); // TODO add sqlcipher_key
+        let _unused_opt = opt.sqlx_logging(false);
         let db = Database::connect(opt).await?;
         let x = db
             .execute(Statement::from_string(
@@ -226,7 +227,7 @@ fn command_from_string(cmd: &str) -> Result<Command, anyhow::Error> {
     let mut command = Command::new(base);
     for ent in entries {
         if ent != base {
-            command.arg(ent);
+            let _unused_command = command.arg(ent);
         }
     }
     Ok(command)

--- a/auraed/src/observe/mod.rs
+++ b/auraed/src/observe/mod.rs
@@ -78,7 +78,7 @@ impl Observe for ObserveService {
 
         // TODO: error handling. Warning: recursively logging if error message is also send to this grpc api endpoint
         //  .. thus disabled logging here.
-        let _unused_join_handle = tokio::spawn(async move {
+        let _ = tokio::spawn(async move {
             // Log consumer will error if:
             //  the producer is closed (no more logs)
             //  the receiver is lagging

--- a/auraed/src/observe/mod.rs
+++ b/auraed/src/observe/mod.rs
@@ -78,7 +78,7 @@ impl Observe for ObserveService {
 
         // TODO: error handling. Warning: recursively logging if error message is also send to this grpc api endpoint
         //  .. thus disabled logging here.
-        tokio::spawn(async move {
+        let _unused_join_handle = tokio::spawn(async move {
             // Log consumer will error if:
             //  the producer is closed (no more logs)
             //  the receiver is lagging

--- a/auraescript/macros/src/lib.rs
+++ b/auraescript/macros/src/lib.rs
@@ -48,7 +48,7 @@
         unused_extern_crates,
         unused_import_braces,
         unused_qualifications,
-        // TODO: unused_results
+        unused_results
         )]
 
 use proc_macro::TokenStream;

--- a/auraescript/src/bin/main.rs
+++ b/auraescript/src/bin/main.rs
@@ -46,7 +46,8 @@
         unused_extern_crates,
         unused_import_braces,
         unused_qualifications,
-        // TODO: unused_results
+        // TODO: enable this once we're out of the rhai game.
+        // unused_results
         )]
 #![warn(clippy::unwrap_used)]
 

--- a/auraescript/src/lib.rs
+++ b/auraescript/src/lib.rs
@@ -51,7 +51,8 @@
         trivial_numeric_casts,
         unused_extern_crates,
         unused_import_braces,
-        // TODO: unused_results
+        // TODO: enable this once we're out of the rhai game.
+        // unused_results
         )]
 // The project prefers .expect("reason") instead of .unwrap() so we fail
 // on any .unwrap() statements in the code.


### PR DESCRIPTION
enable this everywhere, with explicit `_unused` variables where necessary.  this is good as it helps document intent.

auraescript is not included here because rhai engine creation is going to be ripped out and that's the main blocker to enabling the warning.