### PR TITLE
Initial validation integration step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,8 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "validation",
+ "validation_macros",
  "walkdir",
 ]
 

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -62,6 +62,8 @@ libcontainer     = { git = "https://github.com/containers/youki.git", tag = "v0.
 liboci-cli     = { git = "https://github.com/containers/youki.git", tag = "v0.0.2" }
 aurae-proto = { path = "../aurae-proto", version="0.1.0" }
 cgroups-rs =  { git = "https://github.com/kata-containers/cgroups-rs", branch = "main"}
+validation = { path = "../crates/validation", features=["regex"] }
+validation_macros = { path = "../crates/validation/macros" }
 
 [build-dependencies]
 anyhow = "1.0.65"

--- a/auraed/src/runtime/cell_name.rs
+++ b/auraed/src/runtime/cell_name.rs
@@ -1,0 +1,38 @@
+use std::ops::Deref;
+use validation::ValidationError;
+
+#[derive(Debug)]
+pub(crate) struct CellName(String);
+
+impl validation::ValidatedField<String> for CellName {
+    fn validate(
+        input: Option<String>,
+        field_name: &str,
+        parent_name: Option<&str>,
+    ) -> Result<Self, ValidationError> {
+        let input =
+            validation::required_not_empty(input, field_name, parent_name)?;
+
+        // TODO: what makes a valid cgroup name
+        // any valid path?
+        // do we want a restriction on length?
+        // anything else?
+        // Highly restrictive for now:
+        validation::allow_regex(
+            &input,
+            &validation::DOMAIN_NAME_LABEL_REGEX,
+            field_name,
+            parent_name,
+        )?;
+
+        Ok(Self(input))
+    }
+}
+
+impl Deref for CellName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/auraed/src/runtime/free_cell.rs
+++ b/auraed/src/runtime/free_cell.rs
@@ -1,0 +1,27 @@
+use crate::runtime::cell_name::CellName;
+use crate::runtime::CellService;
+use aurae_proto::runtime::{FreeCellRequest, FreeCellResponse};
+use tonic::Status;
+use validation_macros::ValidatedType;
+
+#[derive(ValidatedType)]
+pub(crate) struct ValidatedFreeCellRequest {
+    #[field_type(String)]
+    #[validate]
+    pub cell_name: CellName,
+}
+
+impl FreeCellRequestTypeValidator for FreeCellRequestValidator {}
+
+impl ValidatedFreeCellRequest {
+    pub(crate) fn handle(
+        self,
+        context: &CellService,
+    ) -> Result<FreeCellResponse, Status> {
+        let ValidatedFreeCellRequest { cell_name } = self;
+
+        context.remove_cgroup(&cell_name).expect("remove cgroup");
+
+        Ok(FreeCellResponse {})
+    }
+}

--- a/crates/validation/macros/src/lib.rs
+++ b/crates/validation/macros/src/lib.rs
@@ -78,7 +78,7 @@ pub fn validating_type(input: TokenStream) -> TokenStream {
 }
 
 /// Same as `ValidatingType`, but the `validation` function is on the validated type.
-#[proc_macro_derive(ValidatedType, attributes(field_type))]
+#[proc_macro_derive(ValidatedType, attributes(field_type, validate))]
 pub fn validated_type(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 

--- a/examples/cell_validation_errors.ts
+++ b/examples/cell_validation_errors.ts
@@ -1,0 +1,16 @@
+// [ Free ]
+import * as runtime from "../auraescript/gen/runtime.ts";
+import * as helpers from "../auraescript/gen/helpers.ts";
+
+let cells = new runtime.CellServiceClient();
+
+//// REQUIRED
+// let freed = await cells.free(<runtime.FreeCellRequest>{
+//     cellName: ""
+// });
+
+//// REGEX violation
+let freed = await cells.free(<runtime.FreeCellRequest>{
+    cellName: "nope_nope"
+});
+helpers.print(freed)


### PR DESCRIPTION
This only integrates validation for CellService.free as a first step to show the pattern.

Things that changed:
- We now have a dedicated type for cell_name, `CellName`, with centralized validation. Ideally we shouldn't be doing strict validation of `cell_name` on `free` (required_not_empty may be enough), and only run the stricter validation on `allocate` when creating the cgroup, but I wanted to show more of how things work.
- The `free_cell` endpoint has its own file where the related logic can all exist together. I think this leads to cleaner code.
- If you look at the code in CellService.free, you can see how it's essentially becoming boilerplate (besides the `info!`) and we can write a macro to write it for us as long as we keep a consistent signature on `handle`. 