### PR TITLE
Modeling cells module errors

### DIFF
--- a/auraed/src/runtime/cells/cell.rs
+++ b/auraed/src/runtime/cells/cell.rs
@@ -186,7 +186,7 @@ pub(crate) enum CellError {
     ExecutableNotFound { cell_name: CellName, executable_name: ExecutableName },
     #[error("cell '{cell_name}': {source}")]
     ExecutableError { cell_name: CellName, source: ExecutableError },
-    #[error("cell '{cell_name}' failed to add executable (executable:?)")]
+    #[error("cell '{cell_name}' failed to add executable (executable:?): {source}")]
     FailedToAddExecutable {
         cell_name: CellName,
         executable: Executable,
@@ -203,13 +203,9 @@ impl From<CellError> for Status {
             | CellError::ExecutableExists { .. } => Status::already_exists(msg),
             CellError::CellNotFound { .. }
             | CellError::ExecutableNotFound { .. } => Status::not_found(msg),
-            // TODO (future-highway): I don't know what the conventions are of revealing
-            //  messages that reveal the workings of the system to the api consumer
-            //  in this type of application.
-            //  For now, taking the safe route and not exposing the error messages for the below errors.
             CellError::ExecutableError { .. }
             | CellError::FailedToFreeCell { .. }
-            | CellError::FailedToAddExecutable { .. } => Status::internal(""),
+            | CellError::FailedToAddExecutable { .. } => Status::internal(msg),
         }
     }
 }

--- a/auraed/src/runtime/cells/cell.rs
+++ b/auraed/src/runtime/cells/cell.rs
@@ -42,6 +42,8 @@ use std::process::{Command, ExitStatus};
 use thiserror::Error;
 use tonic::Status;
 
+type Result<T> = std::result::Result<T, CellError>;
+
 #[derive(Debug)]
 pub(crate) struct Cell {
     name: CellName,
@@ -72,7 +74,7 @@ impl Cell {
         Self { name, cgroup, executables: Default::default() }
     }
 
-    pub fn free(self) -> Result<(), CellError> {
+    pub fn free(self) -> Result<()> {
         self.cgroup.delete().map_err(|e| CellError::FailedToFree {
             cell_name: self.name.clone(),
             source: e,
@@ -87,7 +89,7 @@ impl Cell {
         mut command: Command,
         args: Vec<String>,
         _description: String,
-    ) -> Result<(), CellError> {
+    ) -> Result<()> {
         // Check if there was already an executable with the same name.
         if self.executables.contains_key(&exe_name) {
             return Err(CellError::ExecutableExists {
@@ -143,7 +145,7 @@ impl Cell {
     pub fn stop_executable(
         &mut self,
         exe_name: &ExecutableName,
-    ) -> Result<ExitStatus, CellError> {
+    ) -> Result<ExitStatus> {
         if let Some(mut exe) = self.executables.remove(exe_name) {
             match exe.kill() {
                 Ok(exit_status) => Ok(exit_status),

--- a/auraed/src/runtime/cells/cell_service.rs
+++ b/auraed/src/runtime/cells/cell_service.rs
@@ -28,6 +28,7 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
+use crate::runtime::cells::error::CellServiceError;
 use crate::runtime::cells::validation::{
     ValidatedAllocateCellRequest, ValidatedExecutable,
     ValidatedFreeCellRequest, ValidatedStartCellRequest,
@@ -116,6 +117,7 @@ impl CellService {
                     args,
                     description,
                 )
+                .map_err(CellServiceError::from)
             })?;
         }
 
@@ -135,6 +137,7 @@ impl CellService {
 
         let _exit_status = self.cells.get_then(&cell_name, move |cell| {
             cell.stop_executable(&executable_name)
+                .map_err(CellServiceError::from)
         })?;
 
         Ok(Response::new(StopCellResponse::default()))

--- a/auraed/src/runtime/cells/cell_service.rs
+++ b/auraed/src/runtime/cells/cell_service.rs
@@ -63,7 +63,7 @@ impl CellService {
         info!("CellService: allocate() cell={:?}", cell);
 
         if self.cells.contains(&cell.name)? {
-            return Err(CellError::Exists { cell_name: cell.name }.into());
+            return Err(CellError::CellExists { cell_name: cell.name }.into());
         }
 
         let cell_name = cell.name.clone();

--- a/auraed/src/runtime/cells/cell_service.rs
+++ b/auraed/src/runtime/cells/cell_service.rs
@@ -35,7 +35,6 @@ use crate::runtime::cells::validation::{
 };
 use crate::runtime::cells::{Cell, CellsError, CellsTable};
 use ::validation::ValidatedType;
-use anyhow::anyhow;
 use aurae_proto::runtime::{
     cell_service_server, AllocateCellRequest, AllocateCellResponse,
     FreeCellRequest, FreeCellResponse, StartCellRequest, StartCellResponse,
@@ -63,11 +62,7 @@ impl CellService {
         info!("CellService: allocate() cell={:?}", cell);
 
         if self.cells.contains(&cell.name)? {
-            return Err(CellsError::Other(anyhow!(
-                "cell '{}' already exists",
-                cell.name
-            ))
-            .into());
+            return Err(CellsError::CellExists { cell_name: cell.name }.into());
         }
 
         let cell_name = cell.name.clone();

--- a/auraed/src/runtime/cells/cell_service.rs
+++ b/auraed/src/runtime/cells/cell_service.rs
@@ -33,7 +33,7 @@ use crate::runtime::cells::validation::{
     ValidatedFreeCellRequest, ValidatedStartCellRequest,
     ValidatedStopCellRequest,
 };
-use crate::runtime::cells::{Cell, CellsError, CellsTable};
+use crate::runtime::cells::{Cell, CellError, CellsTable};
 use ::validation::ValidatedType;
 use aurae_proto::runtime::{
     cell_service_server, AllocateCellRequest, AllocateCellResponse,
@@ -62,7 +62,7 @@ impl CellService {
         info!("CellService: allocate() cell={:?}", cell);
 
         if self.cells.contains(&cell.name)? {
-            return Err(CellsError::CellExists { cell_name: cell.name }.into());
+            return Err(CellError::Exists { cell_name: cell.name }.into());
         }
 
         let cell_name = cell.name.clone();

--- a/auraed/src/runtime/cells/cell_service.rs
+++ b/auraed/src/runtime/cells/cell_service.rs
@@ -110,7 +110,7 @@ impl CellService {
             );
 
             self.cells.get_then(&cell_name, move |cell| {
-                cell.spawn_executable(
+                cell.start_executable(
                     executable_name,
                     command,
                     args,
@@ -134,7 +134,7 @@ impl CellService {
         );
 
         let _exit_status = self.cells.get_then(&cell_name, move |cell| {
-            cell.kill_executable(&executable_name)
+            cell.stop_executable(&executable_name)
         })?;
 
         Ok(Response::new(StopCellResponse::default()))

--- a/auraed/src/runtime/cells/cells_table.rs
+++ b/auraed/src/runtime/cells/cells_table.rs
@@ -65,7 +65,7 @@ impl CellsTable {
 
         // Check if there was already a cgroup in the table with this cell name as a key.
         if cache.contains_key(&cell_name) {
-            return Err(CellError::Exists { cell_name }.into());
+            return Err(CellError::CellExists { cell_name }.into());
         }
         // Ignoring return value as we've already assured ourselves that the key does not exist.
         let _ = cache.insert(cell_name, cell);
@@ -105,7 +105,7 @@ impl CellsTable {
         if let Some(cell) = cache.get_mut(cell_name) {
             f(cell)
         } else {
-            Err(CellError::NotFound { cell_name: cell_name.clone() }.into())
+            Err(CellError::CellNotFound { cell_name: cell_name.clone() }.into())
         }
     }
 
@@ -118,7 +118,7 @@ impl CellsTable {
             .map_err(|_| CellServiceError::FailedToObtainLock())?;
 
         cache.remove(cell_name).ok_or_else(|| {
-            CellError::NotFound { cell_name: cell_name.clone() }.into()
+            CellError::CellNotFound { cell_name: cell_name.clone() }.into()
         })
     }
 }

--- a/auraed/src/runtime/cells/error.rs
+++ b/auraed/src/runtime/cells/error.rs
@@ -1,3 +1,4 @@
+use crate::runtime::cells::{CellName, ExecutableName};
 use log::error;
 use std::io;
 use thiserror::Error;
@@ -7,13 +8,23 @@ pub(crate) type Result<T> = std::result::Result<T, CellsError>;
 
 #[derive(Error, Debug)]
 pub(crate) enum CellsError {
-    // TODO: define the errors better
+    #[error("cell '{cell_name}' already exists'")]
+    CellExists { cell_name: CellName },
+    #[error("cell '{cell_name}' not found'")]
+    CellNotFound { cell_name: CellName },
+    #[error(
+        "executable '{executable_name}' already exists in cell '{cell_name}'"
+    )]
+    ExecutableExists { cell_name: CellName, executable_name: ExecutableName },
+    #[error("executable '{executable_name}' not found in '{cell_name}'")]
+    ExecutableNotFound { cell_name: CellName, executable_name: ExecutableName },
+    #[error("failed to lock cells cache")]
+    FailedToObtainLock(),
+    // TODO: ideally have the below be better
     #[error(transparent)]
     CgroupsError(#[from] cgroups_rs::error::Error),
     #[error(transparent)]
     Io(#[from] io::Error),
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
 }
 
 impl From<CellsError> for Status {
@@ -21,9 +32,22 @@ impl From<CellsError> for Status {
         let msg = err.to_string();
         error!("{msg}");
         match err {
-            CellsError::CgroupsError { .. }
-            | CellsError::Io { .. }
-            | CellsError::Other { .. } => Self::internal(msg),
+            CellsError::CellExists { .. }
+            | CellsError::ExecutableExists { .. } => {
+                Status::already_exists(msg)
+            }
+            CellsError::CellNotFound { .. }
+            | CellsError::ExecutableNotFound { .. } => Status::not_found(msg),
+            CellsError::FailedToObtainLock() => {
+                // TODO (future-highway): I don't know what the conventions are of revealing
+                //  messages that reveal the workings of the system to the api consumer
+                //  in this type of application.
+                //  For now, taking the safe route and not exposing the error message.
+                Status::aborted("")
+            }
+            CellsError::CgroupsError(_) | CellsError::Io(_) => {
+                Status::internal("")
+            }
         }
     }
 }

--- a/auraed/src/runtime/cells/error.rs
+++ b/auraed/src/runtime/cells/error.rs
@@ -1,56 +1,23 @@
-use crate::runtime::cells::executable::{Executable, ExecutableError};
-use crate::runtime::cells::{CellName, ExecutableName};
+use crate::runtime::cells::cell::CellError;
 use log::error;
 use thiserror::Error;
 use tonic::Status;
 
-pub(crate) type Result<T> = std::result::Result<T, CellError>;
+pub(crate) type Result<T> = std::result::Result<T, CellServiceError>;
 
 #[derive(Error, Debug)]
-pub(crate) enum CellError {
-    #[error("cell '{cell_name}' already exists'")]
-    Exists { cell_name: CellName },
-    #[error("cell '{cell_name}' not found'")]
-    NotFound { cell_name: CellName },
-    #[error("cell '{cell_name}' could not be freed: {source}")]
-    FailedToFree { cell_name: CellName, source: cgroups_rs::error::Error },
-    #[error(
-        "cell '{cell_name}' already has an executable '{executable_name}'"
-    )]
-    ExecutableExists { cell_name: CellName, executable_name: ExecutableName },
-    #[error("cell '{cell_name} could not find executable '{executable_name}'")]
-    ExecutableNotFound { cell_name: CellName, executable_name: ExecutableName },
-    #[error("cell '{cell_name}': {source}")]
-    ExecutableError { cell_name: CellName, source: ExecutableError },
-    #[error("cell '{cell_name}' failed to add executable (executable:?)")]
-    FailedToAddExecutable {
-        cell_name: CellName,
-        executable: Executable,
-        source: cgroups_rs::error::Error,
-    },
-    // TODO: this error seems out of place
+pub(crate) enum CellServiceError {
+    #[error(transparent)]
+    CellError(#[from] CellError),
     #[error("failed to lock cells cache")]
     FailedToObtainLock(),
 }
 
-impl From<CellError> for Status {
-    fn from(err: CellError) -> Self {
-        let msg = err.to_string();
-        error!("{msg}");
+impl From<CellServiceError> for Status {
+    fn from(err: CellServiceError) -> Self {
         match err {
-            CellError::Exists { .. } | CellError::ExecutableExists { .. } => {
-                Status::already_exists(msg)
-            }
-            CellError::NotFound { .. }
-            | CellError::ExecutableNotFound { .. } => Status::not_found(msg),
-            // TODO (future-highway): I don't know what the conventions are of revealing
-            //  messages that reveal the workings of the system to the api consumer
-            //  in this type of application.
-            //  For now, taking the safe route and not exposing the error messages for the below errors.
-            CellError::FailedToObtainLock() => Status::aborted(""),
-            CellError::ExecutableError { .. }
-            | CellError::FailedToFree { .. }
-            | CellError::FailedToAddExecutable { .. } => Status::internal(""),
+            CellServiceError::CellError(err) => err.into(),
+            CellServiceError::FailedToObtainLock() => Status::aborted(""),
         }
     }
 }

--- a/auraed/src/runtime/cells/error.rs
+++ b/auraed/src/runtime/cells/error.rs
@@ -9,7 +9,7 @@ pub(crate) type Result<T> = std::result::Result<T, CellServiceError>;
 pub(crate) enum CellServiceError {
     #[error(transparent)]
     CellError(#[from] CellError),
-    #[error("failed to lock cells cache")]
+    #[error("failed to lock cells table")]
     FailedToObtainLock(),
 }
 
@@ -17,7 +17,9 @@ impl From<CellServiceError> for Status {
     fn from(err: CellServiceError) -> Self {
         match err {
             CellServiceError::CellError(err) => err.into(),
-            CellServiceError::FailedToObtainLock() => Status::aborted(""),
+            CellServiceError::FailedToObtainLock() => {
+                Status::aborted(err.to_string())
+            }
         }
     }
 }

--- a/auraed/src/runtime/cells/executable.rs
+++ b/auraed/src/runtime/cells/executable.rs
@@ -2,8 +2,11 @@ use crate::runtime::cells::ExecutableName;
 use cgroups_rs::CgroupPid;
 use log::info;
 use std::io;
+use std::os::unix::process::CommandExt;
 use std::process::{Child, Command, ExitStatus};
 use thiserror::Error;
+
+type Result<T> = std::result::Result<T, ExecutableError>;
 
 // TODO: I don't know how I (future-highway) feel about this now that I've spun out
 //   `ExecutableError` from `CellsError`. It allows for consuming `Command` on `start`
@@ -36,7 +39,27 @@ impl Executable {
     pub fn start(
         name: ExecutableName,
         mut command: Command,
-    ) -> Result<Self, ExecutableError> {
+        args: Vec<String>,
+        _description: String,
+    ) -> Result<Self> {
+        // Currently takes and returns &mut Command. Calling it as `command.args(args)` leaves us
+        // vulnerable to the implementation changing to taking ownership and returning a new command,
+        // which we then ignore with `let _ =`. To prevent that vulnerability, ensure `.args` takes
+        // command as a &mut, so we always retain ownership, or the compiler errors.
+        // This is done (instead of just reassigning) so that the command can be passed into the error.
+        #[allow(clippy::needless_borrow)]
+        let _ = (&mut command).args(args);
+
+        // Run 'pre_exec' hooks from the context of the soon-to-be launched child.
+        let _ = {
+            let name_clone = name.clone();
+            unsafe {
+                #[allow(clippy::needless_borrow)]
+                (&mut command)
+                    .pre_exec(move || aurae_process_pre_exec(&name_clone))
+            }
+        };
+
         match command.spawn() {
             Ok(child) => Ok(Self { name, child }),
             Err(e) => Err(ExecutableError::FailedToStart {
@@ -47,7 +70,7 @@ impl Executable {
         }
     }
 
-    pub fn kill(&mut self) -> Result<ExitStatus, ExecutableError> {
+    pub fn kill(&mut self) -> Result<ExitStatus> {
         let id = self.child.id();
 
         self.child.kill().map_err(|e| {
@@ -72,5 +95,32 @@ impl Executable {
 
     pub fn pid(&self) -> CgroupPid {
         (self.child.id() as u64).into()
+    }
+}
+
+fn aurae_process_pre_exec(exe_name: &ExecutableName) -> io::Result<()> {
+    info!("CellService: aurae_process_pre_exec(): {exe_name}");
+    // Here we are executing as the new spawned pid.
+    // This is a place where we can "hook" into all processes
+    // started with Aurae in the future. Similar to kprobe/uprobe
+    // in Linux or LD_PRELOAD in libc.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::process::Command;
+
+    #[test]
+    fn test_command_implementation() {
+        let in_args: Vec<OsString> =
+            vec!["hi".into(), "from".into(), "test".into()];
+
+        let mut command = Command::new("echo");
+        let _ = (&mut command).args(in_args.clone());
+        let out_args: Vec<_> =
+            command.get_args().into_iter().map(|x| x.to_os_string()).collect();
+        assert_eq!(in_args, out_args);
     }
 }

--- a/auraed/src/runtime/cells/executable.rs
+++ b/auraed/src/runtime/cells/executable.rs
@@ -7,12 +7,12 @@ use std::process::{Child, Command, ExitStatus};
 pub(crate) struct Executable(Child);
 
 impl Executable {
-    pub fn spawn(mut command: Command) -> io::Result<Self> {
+    pub fn start(mut command: Command) -> io::Result<Self> {
         let child = command.spawn()?;
         Ok(Self(child))
     }
 
-    pub fn kill(mut self) -> io::Result<ExitStatus> {
+    pub fn kill(&mut self) -> io::Result<ExitStatus> {
         let id = self.0.id();
         self.0.kill()?;
         let exit_status = self.0.wait()?;

--- a/auraed/src/runtime/cells/executable.rs
+++ b/auraed/src/runtime/cells/executable.rs
@@ -1,26 +1,76 @@
+use crate::runtime::cells::ExecutableName;
 use cgroups_rs::CgroupPid;
 use log::info;
 use std::io;
 use std::process::{Child, Command, ExitStatus};
+use thiserror::Error;
+
+// TODO: I don't know how I (future-highway) feel about this now that I've spun out
+//   `ExecutableError` from `CellsError`. It allows for consuming `Command` on `start`
+//   (slight safety gain) but probably at the expense of mapping our errors to `Status`.
+//   If there are no security concerns with exposing the underlying errors, then the dev overhead
+//   of mapping to `Status` is no much, but I'm thinking under the assumption that we won't expose.
+#[derive(Error, Debug)]
+pub(crate) enum ExecutableError {
+    #[error("failed to start executable '{executable_name}' ({command:?}) due to: {source}")]
+    FailedToStart {
+        executable_name: ExecutableName,
+        command: Command,
+        source: io::Error,
+    },
+    #[error("failed to stop executable '{executable_name}' ({executable_pid:?}) due to: {source}")]
+    FailedToStopExecutable {
+        executable_name: ExecutableName,
+        executable_pid: CgroupPid,
+        source: io::Error,
+    },
+}
 
 #[derive(Debug)]
-pub(crate) struct Executable(Child);
+pub(crate) struct Executable {
+    name: ExecutableName,
+    child: Child,
+}
 
 impl Executable {
-    pub fn start(mut command: Command) -> io::Result<Self> {
-        let child = command.spawn()?;
-        Ok(Self(child))
+    pub fn start(
+        name: ExecutableName,
+        mut command: Command,
+    ) -> Result<Self, ExecutableError> {
+        match command.spawn() {
+            Ok(child) => Ok(Self { name, child }),
+            Err(e) => Err(ExecutableError::FailedToStart {
+                executable_name: name,
+                command,
+                source: e,
+            }),
+        }
     }
 
-    pub fn kill(&mut self) -> io::Result<ExitStatus> {
-        let id = self.0.id();
-        self.0.kill()?;
-        let exit_status = self.0.wait()?;
+    pub fn kill(&mut self) -> Result<ExitStatus, ExecutableError> {
+        let id = self.child.id();
+
+        self.child.kill().map_err(|e| {
+            ExecutableError::FailedToStopExecutable {
+                executable_name: self.name.clone(),
+                executable_pid: self.pid(),
+                source: e,
+            }
+        })?;
+
+        let exit_status = self.child.wait().map_err(|e| {
+            ExecutableError::FailedToStopExecutable {
+                executable_name: self.name.clone(),
+                executable_pid: self.pid(),
+                source: e,
+            }
+        })?;
+
         info!("Executable with pid {id} exited with status {exit_status}");
         Ok(exit_status)
     }
 
     pub fn pid(&self) -> CgroupPid {
-        (self.0.id() as u64).into()
+        (self.child.id() as u64).into()
     }
 }

--- a/auraed/src/runtime/cells/mod.rs
+++ b/auraed/src/runtime/cells/mod.rs
@@ -2,7 +2,7 @@ use cell::Cell;
 use cell_name::CellName;
 pub(crate) use cell_service::CellService;
 use cells_table::CellsTable;
-use error::{CellsError, Result};
+use error::{CellError, Result};
 use executable::Executable;
 use executable_name::ExecutableName;
 

--- a/auraed/src/runtime/cells/mod.rs
+++ b/auraed/src/runtime/cells/mod.rs
@@ -1,8 +1,8 @@
-use cell::Cell;
+use cell::{Cell, CellError};
 use cell_name::CellName;
 pub(crate) use cell_service::CellService;
 use cells_table::CellsTable;
-use error::{CellError, Result};
+use error::{CellServiceError, Result};
 use executable::Executable;
 use executable_name::ExecutableName;
 


### PR DESCRIPTION
Made a couple of decisions based on assumptions:

1. We don't want to expose source errors (e.g., io::Error) that reveal the workings of the code, but that seems like it may not be a concern in this project.
2. Splitting errors into smaller focused errors that then feed upward (like I did in `init`) is a good idea. Generally I like it, but the recursiveness of `Cell` is causing me to question that approach in this case.

Overall, part of the goal was to use the language of aurae. For example, "start executable" instead of "spawn command/process/child"