### PR TITLE
Make cells cache more resilient  

### DIFF
--- a/auraed/src/runtime/cells/cell.rs
+++ b/auraed/src/runtime/cells/cell.rs
@@ -110,7 +110,10 @@ impl Cell {
     ) -> Result<()> {
         match &mut self.state {
             CellState::Unallocated(_) => {
-                Err(CellsError::CellNotFound { cell_name: self.name.clone() })
+                // TODO: Do we want to check the system to confirm?
+                Err(CellsError::CellUnallocated {
+                    cell_name: self.name.clone(),
+                })
             }
             CellState::Allocated { cgroup, executables } => {
                 let executable = executable.into();
@@ -171,7 +174,10 @@ impl Cell {
     ) -> Result<Option<ExitStatus>> {
         match &mut self.state {
             CellState::Unallocated(_) => {
-                Err(CellsError::CellNotFound { cell_name: self.name.clone() })
+                // TODO: Do we want to check the system to confirm?
+                Err(CellsError::CellUnallocated {
+                    cell_name: self.name.clone(),
+                })
             }
             CellState::Allocated { executables, .. } => {
                 if let Some(executable) = executables.get_mut(executable_name) {

--- a/auraed/src/runtime/cells/cell_service.rs
+++ b/auraed/src/runtime/cells/cell_service.rs
@@ -84,8 +84,8 @@ impl CellService {
         let ValidatedFreeCellRequest { cell_name } = request;
 
         info!("CellService: free() cell_name={:?}", cell_name);
-        // TODO: We remove and then free, which could fail, losing the ref to the cell
-        self.cells.remove(&cell_name).await?.free()?;
+        self.cells.get_mut(&cell_name, |cell| cell.free()).await?;
+        let _ = self.cells.remove(&cell_name).await?;
 
         Ok(FreeCellResponse::default())
     }

--- a/auraed/src/runtime/cells/cell_service.rs
+++ b/auraed/src/runtime/cells/cell_service.rs
@@ -33,7 +33,6 @@ use super::validation::{
     ValidatedStartCellRequest, ValidatedStopCellRequest,
 };
 use super::{CellsTable, Result};
-use crate::runtime::cells::error::CellsError;
 use ::validation::ValidatedType;
 use aurae_proto::runtime::{
     cell_service_server, AllocateCellRequest, AllocateCellResponse,
@@ -106,7 +105,7 @@ impl CellService {
 
             self.cells
                 .get_mut(&cell_name, move |cell| {
-                    cell.start_executable(executable).map_err(CellsError::from)
+                    cell.start_executable(executable)
                 })
                 .await?;
         }
@@ -128,7 +127,7 @@ impl CellService {
         let _exit_status = self
             .cells
             .get_mut(&cell_name, move |cell| {
-                cell.stop_executable(&executable_name).map_err(CellsError::from)
+                cell.stop_executable(&executable_name)
             })
             .await?;
 
@@ -187,7 +186,7 @@ impl cell_service_server::CellService for CellService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::cells::CellName;
+    use crate::runtime::cells::{CellName, CellsError};
 
     // TODO: run this in a way that creating cgroups works
     #[test]

--- a/auraed/src/runtime/cells/cells_table.rs
+++ b/auraed/src/runtime/cells/cells_table.rs
@@ -74,7 +74,11 @@ impl CellsTable {
         let mut cache = self.cache.lock().await;
 
         if let Some(cell) = cache.get_mut(cell_name) {
-            f(cell)
+            let res = f(cell);
+            if matches!(res, Err(CellsError::CellUnallocated { .. })) {
+                let _ = cache.remove(cell_name);
+            }
+            res
         } else {
             Err(CellsError::CellNotFound { cell_name: cell_name.clone() })
         }

--- a/auraed/src/runtime/cells/cells_table.rs
+++ b/auraed/src/runtime/cells/cells_table.rs
@@ -48,7 +48,11 @@ pub(crate) struct CellsTable {
 impl CellsTable {
     /// Add the [cell] to the cache with key [cell_name].
     /// Returns an error if a duplicate [cell_name] already exists in the cache.
-    pub async fn insert(&self, cell_name: CellName, cell: Cell) -> Result<()> {
+    pub async fn insert<T: Into<Cell>>(
+        &self,
+        cell_name: CellName,
+        cell: T,
+    ) -> Result<()> {
         let mut cache = self.cache.lock().await;
 
         // TODO: replace with this when it becomes stable
@@ -59,14 +63,8 @@ impl CellsTable {
             return Err(CellsError::CellExists { cell_name });
         }
         // Ignoring return value as we've already assured ourselves that the key does not exist.
-        let _ = cache.insert(cell_name, cell);
+        let _ = cache.insert(cell_name, cell.into());
         Ok(())
-    }
-
-    pub async fn contains(&self, cell_name: &CellName) -> Result<bool> {
-        let cache = self.cache.lock().await;
-
-        Ok(cache.contains_key(cell_name))
     }
 
     pub async fn get_mut<F, R>(&self, cell_name: &CellName, f: F) -> Result<R>

--- a/auraed/src/runtime/cells/error.rs
+++ b/auraed/src/runtime/cells/error.rs
@@ -41,8 +41,10 @@ pub(crate) type Result<T> = std::result::Result<T, CellsError>;
 pub(crate) enum CellsError {
     #[error("cell '{cell_name}' already exists'")]
     CellExists { cell_name: CellName },
-    #[error("cell '{cell_name}' not found'")]
+    #[error("cell '{cell_name}' not found")]
     CellNotFound { cell_name: CellName },
+    #[error("cell '{cell_name}' unallocated")]
+    CellUnallocated { cell_name: CellName },
     #[error("cell '{cell_name}' could not be freed: {source}")]
     FailedToFreeCell { cell_name: CellName, source: cgroups_rs::error::Error },
     #[error(
@@ -97,6 +99,9 @@ impl From<CellsError> for Status {
             }
             CellsError::FailedToObtainLock() => {
                 Status::aborted(err.to_string())
+            }
+            CellsError::CellUnallocated { cell_name } => {
+                CellsError::CellNotFound { cell_name }.into()
             }
         }
     }

--- a/auraed/src/runtime/cells/validation.rs
+++ b/auraed/src/runtime/cells/validation.rs
@@ -92,7 +92,7 @@ pub(crate) struct ValidatedStopCellRequest {
 impl StopCellRequestTypeValidator for StopCellRequestValidator {}
 
 // TODO: `#[validate(none)] is used to skip validation. Actually validate when restrictions are known.
-#[derive(Debug, ValidatedType)]
+#[derive(ValidatedType, Debug, Clone)]
 pub(crate) struct ValidatedCell {
     #[field_type(String)]
     #[validate(create)]
@@ -116,6 +116,12 @@ pub(crate) struct ValidatedCell {
 }
 
 impl CellTypeValidator for CellValidator {}
+
+impl From<ValidatedCell> for crate::runtime::cells::Cell {
+    fn from(x: ValidatedCell) -> Self {
+        Self::new(x)
+    }
+}
 
 #[derive(ValidatedType, Debug)]
 pub(crate) struct ValidatedExecutable {


### PR DESCRIPTION
- Cached the Cell in-memory prior to attempting to allocate the cell.
- If an unallocated Cell is encountered in start/stop executable, it is removed from the cache (client sees `CellNotFound`)