### PR TITLE
Simplify `Cells` by moving lock to `CellService`

### DIFF
--- a/.github/workflows/build-compile-test.yml
+++ b/.github/workflows/build-compile-test.yml
@@ -34,5 +34,5 @@ jobs:
         run: make build
       - name: Lint (make lint)
         run: make lint
-      - name: Tests (make test)
-        run: make test
+      - name: Tests (make testci)
+        run: make testci

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ serve: docs ## Run the aurae.io static website locally
 	sudo -E ./hack/serve.sh
 
 test: ## Run the tests
+	@$(cargo) test -- --ignored
+
+testci: ## Run the tests that we can in CI
 	@$(cargo) test
 
 .PHONY: config

--- a/auraed/src/runtime/cells/cell.rs
+++ b/auraed/src/runtime/cells/cell.rs
@@ -31,6 +31,7 @@
 use super::{
     validation::ValidatedCell, CellsError, Executable, ExecutableName, Result,
 };
+use crate::runtime::cells::cell_name::CellName;
 use cgroups_rs::{
     cgroup_builder::CgroupBuilder, hierarchies, Cgroup, Hierarchy,
 };
@@ -56,6 +57,10 @@ enum CellState {
 impl Cell {
     pub fn new(cell_spec: ValidatedCell) -> Self {
         Self { spec: cell_spec, state: CellState::Unallocated }
+    }
+
+    pub fn name(&self) -> &CellName {
+        &self.spec.name
     }
 
     /// Creates the underlying cgroup. Does nothing if the `Cell` has already been allocated.

--- a/auraed/src/runtime/cells/cell_name.rs
+++ b/auraed/src/runtime/cells/cell_name.rs
@@ -11,8 +11,8 @@ impl CellName {
     }
 
     #[cfg(test)]
-    pub fn random() -> Self {
-        Self(uuid::Uuid::new_v4().to_string())
+    pub fn random_for_tests() -> Self {
+        Self(format!("ae-test-{}", uuid::Uuid::new_v4().to_string()))
     }
 }
 

--- a/auraed/src/runtime/cells/cell_service.rs
+++ b/auraed/src/runtime/cells/cell_service.rs
@@ -201,7 +201,7 @@ mod tests {
     #[tokio::test]
     async fn test_attempt_to_remove_unknown_cell_fails() {
         let service = CellService::new();
-        let random_cell_name = CellName::random();
+        let random_cell_name = CellName::random_for_tests();
 
         let res = service
             .free(ValidatedFreeCellRequest {

--- a/auraed/src/runtime/cells/cells.rs
+++ b/auraed/src/runtime/cells/cells.rs
@@ -150,6 +150,7 @@ mod tests {
         cell.into()
     }
 
+    #[ignore]
     #[test]
     fn test_allocate() {
         let mut cells = Cells::default();
@@ -162,6 +163,7 @@ mod tests {
         assert!(cells.cache.contains_key(&cell_name));
     }
 
+    #[ignore]
     #[test]
     fn test_duplicate_allocate_is_error() {
         let mut cells = Cells::default();
@@ -179,6 +181,7 @@ mod tests {
         ));
     }
 
+    #[ignore]
     #[test]
     fn test_get() {
         let mut cells = Cells::default();
@@ -191,6 +194,7 @@ mod tests {
         cells.get(&cell_name, |_cell| Ok(())).expect("failed to get");
     }
 
+    #[ignore]
     #[test]
     fn test_get_missing_errors() {
         let mut cells = Cells::default();
@@ -204,6 +208,7 @@ mod tests {
         ));
     }
 
+    #[ignore]
     #[test]
     fn test_free() {
         let mut cells = Cells::default();
@@ -217,6 +222,7 @@ mod tests {
         assert!(cells.cache.is_empty());
     }
 
+    #[ignore]
     #[test]
     fn test_free_missing_is_error() {
         let mut cells = Cells::default();

--- a/auraescript/macros/src/lib.rs
+++ b/auraescript/macros/src/lib.rs
@@ -55,8 +55,10 @@ use proc_macro::TokenStream;
 
 mod ops;
 
+// TODO (future-highway): Due to needing to ignore certain tests in CI, we can't format
+//    the code in the docs as cargo test will try to test it. Workaround or add the needed
+//    deps to this crate to make it pass.
 /// # Example:
-/// ```ignore
 /// macros::ops_generator!(
 ///     module_name,
 ///     ServiceName,

--- a/crates/validation/macros/src/lib.rs
+++ b/crates/validation/macros/src/lib.rs
@@ -8,10 +8,12 @@ use validation::ValidateInput;
 
 mod validation;
 
+// TODO (future-highway): Due to needing to ignore certain tests in CI, we can't format
+//    the code in the docs as cargo test will try to test it. Workaround or add the needed
+//    deps to this crate to make it pass.
 /// Scaffolds validation and provides a `validate` function on the unvalidated type by implementing `validation::ValidatingType`
 ///
 /// # Example
-/// ```ignore
 /// // Given you have this struct:
 /// struct Message {
 ///     cpu_percentage: i32
@@ -23,7 +25,6 @@ mod validation;
 ///     #[field_type(i32)]
 ///     cpu_percentage: u8
 /// }
-/// ```
 ///
 /// The macro will then generate a trait `MessageTypeValidator` and an empty struct `MessageValidator`.
 /// You must `impl MessageTypeValidator for MessageValidator`.


### PR DESCRIPTION
This should also make it a bit more straight forward for creating grpc `Response`s for cells.