### PR TITLE
Make pki directory for certgen, if missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ tlsinfo: ## Show TLS Info for /var/run/aurae*
 .PHONY: pki
 pki: certs ## Alias for certs
 certs: clean-certs ## Generate x509 mTLS certs in /pki directory
+	mkdir -p pki
 	./hack/certgen
 	sudo -E mkdir -p /etc/aurae/pki
 	sudo -E cp -v pki/* /etc/aurae/pki


### PR DESCRIPTION
As reported by rwxrick in the discord (and I ran into this myself just now as I needed to start from scratch), the `make pki` command requires a pki directory. 