### PR TITLE
fix blog links to ISO 8601

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -94,4 +94,4 @@ A notable exception to the public specification above is the Aurae projects pref
 The traditional convention that is meant to reduce the likelihood of future breaking changes and ease the creation of macros for generating code:
 
 - rpc methods (e.g., `StartWidget`) should have dedicated request and response messages named `StartWidgetResponse` and `StartWidgetResponse`
-- objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetReqyest`, etc style methods.
+- objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetRequest`, etc style methods.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 
 Aurae is a free and open source Rust project which houses a memory-safe systems runtime daemon built specifically for enterprise distributed systems called `auraed`.
 
-The `auraed` daemon can be ran as a pid 1 on a Linux kernel and manages containers, virtual machines, and spawning short-lived nested virtual instances of itself for an additional layer of isolation.
+The `auraed` daemon can be run as a pid 1 on a Linux kernel and manages containers, virtual machines, and spawning short-lived nested virtual instances of itself for an additional layer of isolation.
 
 ### Mission
 
@@ -46,7 +46,7 @@ Aurae exposes its functionality over a gRPC API which is referred to as the [Aur
 
 ### Principle of Least Awareness
 
-A single Aurae instance has no awareness of higher order scheduling mechanisms such as the Kubernetes control plane. Aurae is designed to take ownership of a single node, and expose the standard library a generic and meaningful way for higher order consumers.
+A single Aurae instance has no awareness of higher order scheduling mechanisms such as the Kubernetes control plane. Aurae is designed to take ownership of a single node, and expose the standard library as a generic and meaningful way for higher order consumers.
 
 Aurae is a low level building block and is designed to work well with any higher order system by offering a thoughtful set of APIs and controls for managing workloads on a node.
 

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -94,4 +94,4 @@ A notable exception to the public specification above is the Aurae projects pref
 The traditional convention that is meant to reduce the likelihood of future breaking changes and ease the creation of macros for generating code:
 
 - rpc methods (e.g., `StartWidget`) should have dedicated request and response messages named `StartWidgetResponse` and `StartWidgetResponse`
-- objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetReqyest`, etc style methods.
+- objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetRequest`, etc style methods.

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -94,4 +94,4 @@ A notable exception to the public specification above is the Aurae projects pref
 The traditional convention that is meant to reduce the likelihood of future breaking changes and ease the creation of macros for generating code:
 
 - rpc methods (e.g., `StartWidget`) should have dedicated request and response messages named `StartWidgetResponse` and `StartWidgetResponse`
-- objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetRequest`, etc style methods.
+- objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetReqyest`, etc style methods.

--- a/docs/stdlib/v0/index.md
+++ b/docs/stdlib/v0/index.md
@@ -195,7 +195,6 @@ The most primitive workload in Aurae, a standard executable process.
 | ----- | ---- | ----- | ----------- |
 | name | [string](#string) |  |  |
 | command | [string](#string) |  |  |
-| args | [string](#string) | repeated |  |
 | description | [string](#string) |  |  |
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,8 @@ nav:
       - auraescript: /crate/src/auraescript/lib.rs.html
       - macros: /crate/src/macros/lib.rs.html
   - Blog:
-      - Isolation with Aurae Cells: /blog/24-10-2022-aurae-cells
+      - Isolation with Aurae Cells: /blog/2022-10-24-aurae-cells
+      - Cgroups in Aurae: /blog/2022-12-11-cgroups
 
 theme:
   name: material


### PR DESCRIPTION
note that the `docs` changes are generated by `make docs` and maybe they shouldn't be checked into the repo.

the `mkdocs.yml` is the only change i made