### PR TITLE
Cells cache reconciliation

### DIFF
--- a/auraed/src/runtime/cell_service/cells/cell.rs
+++ b/auraed/src/runtime/cell_service/cells/cell.rs
@@ -151,9 +151,10 @@ impl Cell {
     }
 }
 
-#[cfg(test)]
 impl Drop for Cell {
-    /// A [Cell] leaves a cgroup behind so we call [free] on drop
+    /// During normal behavior, cells are freed before being dropped,
+    /// but cache reconciliation may result in a drop in other circumstances.
+    /// Here we have a chance to clean up, no matter the circumstance.   
     fn drop(&mut self) {
         let _best_effort = self.free();
     }

--- a/auraed/src/runtime/cell_service/cells/cells.rs
+++ b/auraed/src/runtime/cell_service/cells/cells.rs
@@ -28,12 +28,12 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-use super::{Cell, CellName, CellSpec, CellsError, Result};
+use super::{cgroups::Cgroup, Cell, CellName, CellSpec, CellsError, Result};
 use std::collections::HashMap;
 
 type Cache = HashMap<CellName, Cell>;
 
-/// Cells is the in-memory store for the list of cells created with Aurae.
+/// The in-memory cache of cells ([Cell]) created with Aurae.
 #[derive(Debug, Default)]
 pub struct Cells {
     cache: Cache,
@@ -46,24 +46,30 @@ pub struct Cells {
 // - Get Cgroup and pids from executable_name
 
 impl Cells {
-    /// Add the [Cell] to the cache with key [CellName].
-    /// Returns an error if a duplicate [CellName] already exists in the cache.
+    /// Calls [Cell::allocate] on a new [Cell] and adds it to it's cache with key [CellName].
+    ///
+    /// # Errors
+    /// * If cell exits -> [CellsError::CellExists]
+    /// * If a cell is not in cache but cgroup exists on fs -> [CellsError::CgroupIsNotACell]
+    /// * If cell fails to allocate (see [Cell::allocate])
     pub fn allocate(
         &mut self,
         cell_name: CellName,
         cell_spec: CellSpec,
     ) -> Result<&Cell> {
-        // TODO: replace with this when it becomes stable
-        // cache.try_insert(cell_name.clone(), cgroup)
-
-        // Check if there was already a cgroup in the table with this cell name as a key.
-        if self.cache.contains_key(&cell_name) {
-            // TODO Reconcile cache against filesystem somewhere, maybe here?
-            // TODO https://github.com/aurae-runtime/aurae/issues/198
-            return Err(CellsError::CellExists { cell_name });
+        if Cgroup::exists(&cell_name) {
+            return if self.cache.contains_key(&cell_name) {
+                Err(CellsError::CellExists { cell_name })
+            } else {
+                Err(CellsError::CgroupIsNotACell {
+                    cell_name: cell_name.clone(),
+                })
+            };
         }
 
-        // `or_insert` will always insert as we've already assured ourselves that the key does not exist.
+        // From here, we know the cgroup doesn't exist, so remove from cache if it does
+        let _ = self.cache.remove(&cell_name);
+
         let cell = self
             .cache
             .entry(cell_name.clone())
@@ -73,12 +79,18 @@ impl Cells {
         Ok(cell)
     }
 
-    /// Returns an error if the [CellName] does not exist in the cache.
+    /// Calls [Cell::free] on a [Cell] and removes it from the cache.
+    ///
+    /// # Errors
+    /// * If cell is not cached and cgroup does not exist -> [CellsError::CellNotFound]
+    /// * If cell is cached and cgroup does not exist -> [CellsError::CgroupNotFound]
+    ///     - note: cell will be removed from cache
+    /// * If cell is not cached and cgroup exists on fs -> [CellsError::CgroupIsNotACell]
+    /// * If cell fails to free (see [Cell::free])
     pub fn free(&mut self, cell_name: &CellName) -> Result<()> {
+        self.handle_cgroup_does_not_exist(cell_name)?;
         self.get_mut(cell_name, |cell| cell.free())?;
-        let _ = self.cache.remove(cell_name).ok_or_else(|| {
-            CellsError::CellNotFound { cell_name: cell_name.clone() }
-        })?;
+        let _ = self.cache.remove(cell_name);
         Ok(())
     }
 
@@ -86,26 +98,10 @@ impl Cells {
     where
         F: Fn(&Cell) -> Result<R>,
     {
-        // TODO Also reconcile the cache against the filesystem
-        // TODO https://github.com/aurae-runtime/aurae/issues/198
-        if let Some(cell) = self.cache.get(cell_name) {
-            let res = f(cell);
-            if matches!(res, Err(CellsError::CellNotAllocated { .. })) {
-                let _ = self.cache.remove(cell_name);
-            }
-            res
-        } else {
-            // if we can eliminate this case, we can take &self instead
-            Err(CellsError::CellNotFound { cell_name: cell_name.clone() })
-        }
-    }
+        self.handle_cgroup_does_not_exist(cell_name)?;
 
-    pub fn get_mut<F, R>(&mut self, cell_name: &CellName, f: F) -> Result<R>
-    where
-        F: FnOnce(&mut Cell) -> Result<R>,
-    {
-        let Some(cell) = self.cache.get_mut(cell_name) else {
-            return Err(CellsError::CellNotFound { cell_name: cell_name.clone() });
+        let Some(cell) = self.cache.get(cell_name) else {
+            return Err(CellsError::CgroupIsNotACell { cell_name: cell_name.clone() });
         };
 
         let res = f(cell);
@@ -115,6 +111,44 @@ impl Cells {
         }
 
         res
+    }
+
+    pub fn get_mut<F, R>(&mut self, cell_name: &CellName, f: F) -> Result<R>
+    where
+        F: FnOnce(&mut Cell) -> Result<R>,
+    {
+        self.handle_cgroup_does_not_exist(cell_name)?;
+
+        let Some(cell) = self.cache.get_mut(cell_name) else {
+            return Err(CellsError::CgroupIsNotACell { cell_name: cell_name.clone() });
+        };
+
+        let res = f(cell);
+
+        if matches!(res, Err(CellsError::CellNotAllocated { .. })) {
+            let _ = self.cache.remove(cell_name);
+        }
+
+        res
+    }
+
+    fn handle_cgroup_does_not_exist(
+        &mut self,
+        cell_name: &CellName,
+    ) -> Result<()> {
+        if Cgroup::exists(cell_name) {
+            return Ok(());
+        }
+
+        let Some(_removed) = self.cache.remove(cell_name) else {
+            // Cell doesn't exist & cgroup doesn't exit
+            return Err(CellsError::CellNotFound {
+                cell_name: cell_name.clone(),
+            });
+        };
+
+        // Cell exist, but cgroup doesn't
+        Err(CellsError::CgroupNotFound { cell_name: cell_name.clone() })
     }
 }
 

--- a/auraed/src/runtime/cell_service/cells/cells.rs
+++ b/auraed/src/runtime/cell_service/cells/cells.rs
@@ -73,7 +73,7 @@ impl Cells {
             // TODO: Should we not remove the cell (that has no cgroup) from the cache and
             //       force the user to call Free? Free will also return an error, but we may be
             //       calling other logic in free that we want to run.
-            warn!("found cached cell ('{cell_name}') without cgroup");
+            warn!("Found cached cell ('{cell_name}') without cgroup. Did you forget to call free on the cell?");
         }
 
         let cell = self

--- a/auraed/src/runtime/cell_service/cells/cgroups/cgroup.rs
+++ b/auraed/src/runtime/cell_service/cells/cgroups/cgroup.rs
@@ -32,6 +32,7 @@ use crate::runtime::cell_service::cells::{CellName, CgroupSpec};
 use cgroups_rs::cgroup_builder::CgroupBuilder;
 use cgroups_rs::{hierarchies, Hierarchy};
 use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct Cgroup {
@@ -70,6 +71,12 @@ impl Cgroup {
         //       But when we are deleting the cgroup, we are leaving behind a cgroup
         //       at {CellName}. We need to clean that up.
         cgroups_rs::Cgroup::load(hierarchy(), &*self.cell_name).delete()
+    }
+
+    pub fn exists(cell_name: &CellName) -> bool {
+        let mut path = PathBuf::from("/sys/fs/cgroup");
+        path.push(cell_name.deref());
+        path.exists()
     }
 }
 

--- a/auraed/src/runtime/cell_service/cells/error.rs
+++ b/auraed/src/runtime/cell_service/cells/error.rs
@@ -54,8 +54,10 @@ pub enum CellsError {
     FailedToKillCellChildren { cell_name: CellName, source: io::Error },
     #[error("cell '{cell_name}' could not be freed: {source}")]
     FailedToFreeCell { cell_name: CellName, source: cgroups_rs::error::Error },
-    #[error("a cgroup '{cell_name}' exits on the system, but is not controlled by auraed")]
+    #[error(
+        "cgroup '{cell_name}' exists on host, but is not controlled by auraed"
+    )]
     CgroupIsNotACell { cell_name: CellName },
-    #[error("cell '{cell_name}' did not find cgroup on system")]
+    #[error("cgroup '{cell_name}` not found on host")]
     CgroupNotFound { cell_name: CellName },
 }

--- a/auraed/src/runtime/cell_service/cells/error.rs
+++ b/auraed/src/runtime/cell_service/cells/error.rs
@@ -54,4 +54,8 @@ pub enum CellsError {
     FailedToKillCellChildren { cell_name: CellName, source: io::Error },
     #[error("cell '{cell_name}' could not be freed: {source}")]
     FailedToFreeCell { cell_name: CellName, source: cgroups_rs::error::Error },
+    #[error("a cgroup '{cell_name}' exits on the system, but is not controlled by auraed")]
+    CgroupIsNotACell { cell_name: CellName },
+    #[error("cell '{cell_name}' did not find cgroup on system")]
+    CgroupNotFound { cell_name: CellName },
 }

--- a/auraed/src/runtime/cell_service/error.rs
+++ b/auraed/src/runtime/cell_service/error.rs
@@ -54,7 +54,9 @@ impl From<CellsServiceError> for Status {
                 CellsError::FailedToAllocateCell { .. }
                 | CellsError::AbortedAllocateCell { .. }
                 | CellsError::FailedToKillCellChildren { .. }
-                | CellsError::FailedToFreeCell { .. } => Status::internal(msg),
+                | CellsError::FailedToFreeCell { .. }
+                | CellsError::CgroupIsNotACell { .. }
+                | CellsError::CgroupNotFound { .. } => Status::internal(msg),
                 CellsError::CellNotAllocated { cell_name } => {
                     CellsServiceError::CellsError(CellsError::CellNotFound {
                         cell_name,

--- a/auraed/src/runtime/cell_service/error.rs
+++ b/auraed/src/runtime/cell_service/error.rs
@@ -49,14 +49,16 @@ impl From<CellsServiceError> for Status {
         error!("{msg}");
         match err {
             CellsServiceError::CellsError(e) => match e {
+                CellsError::CgroupIsNotACell { .. } => {
+                    Status::failed_precondition(msg)
+                }
                 CellsError::CellExists { .. } => Status::already_exists(msg),
-                CellsError::CellNotFound { .. } => Status::not_found(msg),
+                CellsError::CellNotFound { .. }
+                | CellsError::CgroupNotFound { .. } => Status::not_found(msg),
                 CellsError::FailedToAllocateCell { .. }
                 | CellsError::AbortedAllocateCell { .. }
                 | CellsError::FailedToKillCellChildren { .. }
-                | CellsError::FailedToFreeCell { .. }
-                | CellsError::CgroupIsNotACell { .. }
-                | CellsError::CgroupNotFound { .. } => Status::internal(msg),
+                | CellsError::FailedToFreeCell { .. } => Status::internal(msg),
                 CellsError::CellNotAllocated { cell_name } => {
                     CellsServiceError::CellsError(CellsError::CellNotFound {
                         cell_name,


### PR DESCRIPTION
Introduced 2 more errors to CellsError:
1. `CgroupNotFound` -> We cached a `cell`, but the `cgroup` is not on the fs
2. `CgroupIsNotACell` -> A `cgroup` exists on the fs, but we don't have a cached cell

Anytime `CgroupNotFound` is encountered, we remove the cell from the cache, so repeated calls won't see the error multiple times.

close #198 