### PR TITLE
capture and log stdout and stderr from executables

### DIFF
--- a/auraed/src/logging/log_channel.rs
+++ b/auraed/src/logging/log_channel.rs
@@ -54,7 +54,7 @@ impl LogChannel {
     }
 
     /// Getter for the name
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &str {
         &self.name
     }
 

--- a/auraed/src/runtime/cell_service/cell_service.rs
+++ b/auraed/src/runtime/cell_service/cell_service.rs
@@ -120,6 +120,10 @@ impl CellService {
                 .map_err(CellsServiceError::ExecutablesError)?;
 
             let pid = executable.pid().expect("pid").as_raw();
+
+            // TODO: either tell the [ObserveService] about this executable's log channels, or
+            // provide a way for the observe service to extract the log channels from here.
+
             Ok(Response::new(StartExecutableResponse { pid }))
         } else {
             // we are in a parent cell

--- a/auraed/src/runtime/cell_service/cell_service.rs
+++ b/auraed/src/runtime/cell_service/cell_service.rs
@@ -119,7 +119,7 @@ impl CellService {
                 .start(executable)
                 .map_err(CellsServiceError::ExecutablesError)?;
 
-            let pid = executable.pid().expect("pid").as_raw();
+            let pid = executable.pid().map_err(CellsServiceError::IO)?.expect("pid").as_raw();
 
             // TODO: either tell the [ObserveService] about this executable's log channels, or
             // provide a way for the observe service to extract the log channels from here.

--- a/auraed/src/runtime/cell_service/error.rs
+++ b/auraed/src/runtime/cell_service/error.rs
@@ -41,6 +41,8 @@ pub(crate) enum CellsServiceError {
     CellsError(#[from] CellsError),
     #[error(transparent)]
     ExecutablesError(#[from] ExecutablesError),
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
 }
 
 impl From<CellsServiceError> for Status {
@@ -78,6 +80,7 @@ impl From<CellsServiceError> for Status {
                     Status::internal(msg)
                 }
             },
+            CellsServiceError::IO(_) => Status::internal(msg),
         }
     }
 }

--- a/auraed/src/runtime/cell_service/executables/executable.rs
+++ b/auraed/src/runtime/cell_service/executables/executable.rs
@@ -1,16 +1,27 @@
 use super::process::Process;
 use super::{ExecutableName, ExecutableSpec};
+use crate::logging::log_channel::LogChannel;
 use nix::sys::signal::SIGKILL;
 use nix::unistd::Pid;
 use std::ffi::OsString;
-use std::process::Command;
-use std::{io, process::ExitStatus};
+use std::fs::File;
+use std::io::BufRead;
+use std::os::unix::prelude::FromRawFd;
+use std::sync::Arc;
+use std::{
+    io,
+    process::{Command, ExitStatus, Stdio},
+};
+use tracing::{event, warn, Level};
 
 #[derive(Debug)]
 pub struct Executable {
     pub name: ExecutableName,
     pub description: String,
     state: ExecutableState,
+    stdout: Arc<LogChannel>,
+    stderr: Arc<LogChannel>,
+    // TODO: log_thread: Option<std::thread::JoinHandle<io::Result<()>>>,
 }
 
 #[derive(Debug)]
@@ -31,7 +42,16 @@ enum ExecutableState {
 impl Executable {
     pub fn new<T: Into<ExecutableSpec>>(spec: T) -> Self {
         let ExecutableSpec { name, description, command } = spec.into();
-        Self { name, description, state: ExecutableState::Init { command } }
+        let stdout = Arc::new(LogChannel::new(format!("{}::stdout", name)));
+        let stderr = Arc::new(LogChannel::new(format!("{}::stderr", name)));
+        Self {
+            name,
+            description,
+            state: ExecutableState::Init { command },
+            stdout,
+            stderr,
+            // TODO: log_thread: None,
+        }
     }
 
     /// Starts the underlying process.
@@ -42,6 +62,8 @@ impl Executable {
         };
 
         let process = exec(command)?;
+
+        // TODO: self.log_thread = Some(self.spawn_log_thread());
 
         self.state = ExecutableState::Started {
             program: command.get_program().to_os_string(),
@@ -54,12 +76,41 @@ impl Executable {
 
     /// Stops the executable and returns the [ExitStatus].
     /// If the executable has never been started, returns [None].
-    pub fn kill(&mut self) -> Result<Option<ExitStatus>, io::Error> {
+    pub fn kill(&mut self) -> io::Result<Option<ExitStatus>> {
         match &mut self.state {
             ExecutableState::Init { .. } => Ok(None),
             ExecutableState::Started { process, .. } => {
                 process.kill(Some(SIGKILL))?;
                 let exit_status = process.wait()?;
+                // TODO
+                //self.log_thread
+                //    .unwrap()
+                //    .join()
+                //    .expect("logging thread panicked")?;
+                for line in self.read_stdout()? {
+                    event!(
+                        Level::INFO,
+                        level = "info",
+                        channel = self.stdout.name(),
+                        line
+                    );
+                    LogChannel::log_line(
+                        self.stdout.get_producer().clone(),
+                        line.to_string(),
+                    );
+                }
+                for line in self.read_stderr()? {
+                    event!(
+                        Level::INFO,
+                        level = "error",
+                        channel = self.stderr.name(),
+                        line
+                    );
+                    LogChannel::log_line(
+                        self.stderr.get_producer().clone(),
+                        line.to_string(),
+                    );
+                }
                 self.state = ExecutableState::Stopped(exit_status);
                 Ok(Some(exit_status))
             }
@@ -75,6 +126,117 @@ impl Executable {
 
         Some(process.pid())
     }
+
+    /// Returns any unread lines from stdout if [Executable] is running, otherwise returns an empty
+    /// [Vec].
+    pub fn read_stdout(&mut self) -> io::Result<Vec<String>> {
+        let ExecutableState::Started { process, .. } = &mut self.state else {
+            warn!("attempted to read stdout on process that was not started");
+            return Ok(vec![]);
+        };
+
+        let mut output = Vec::new();
+        match process {
+            Process::Spawned(child) => {
+                if let Some(stdout) = child.stdout.as_mut() {
+                    for line in io::BufReader::new(stdout).lines() {
+                        output.push(line?);
+                    }
+                };
+            }
+            Process::Cloned { process, .. } => {
+                let fd = process
+                    .fd_from_fd(1)
+                    .map_err(|e| {
+                        io::Error::new(io::ErrorKind::BrokenPipe, e.to_string())
+                    })?
+                    .fd;
+                let f = unsafe { File::from_raw_fd(fd) };
+
+                for line in io::BufReader::new(f).lines() {
+                    output.push(line?);
+                }
+            }
+        };
+        Ok(output)
+    }
+
+    /// Returns any unread lines from stderr if [Executable] is running, otherwise returns an empty
+    /// [Vec].
+    pub fn read_stderr(&mut self) -> io::Result<Vec<String>> {
+        let ExecutableState::Started { process, .. } = &mut self.state else {
+            return Ok(vec![]);
+        };
+
+        let mut output = Vec::new();
+        match process {
+            Process::Spawned(child) => {
+                if let Some(stdout) = child.stderr.as_mut() {
+                    for line in io::BufReader::new(stdout).lines() {
+                        output.push(line?);
+                    }
+                };
+            }
+            Process::Cloned { process, .. } => {
+                let fd = process
+                    .fd_from_fd(2)
+                    .map_err(|e| {
+                        io::Error::new(io::ErrorKind::BrokenPipe, e.to_string())
+                    })?
+                    .fd;
+                let f = unsafe { File::from_raw_fd(fd) };
+                for line in io::BufReader::new(f).lines() {
+                    output.push(line?);
+                }
+            }
+        };
+        Ok(output)
+    }
+
+    // TODO:
+    // /// Spawns a thread that produces log lines while the [Executable] is running.
+    // fn spawn_log_thread(&mut self) -> std::thread::JoinHandle<io::Result<()>> {
+    //     let local_stdout = self.stdout.clone();
+    //     let local_stderr = self.stderr.clone();
+    //     std::thread::spawn(move || -> io::Result<()> {
+    //         let mut running = true;
+    //         while running {
+    //             match self.state {
+    //                 ExecutableState::Init { .. } => {}
+    //                 ExecutableState::Started { .. } => {
+    //                     // TODO: consider changing the pipes to use io::BufReader::new(file).lines()
+    //                     // and iterating over those lines here.
+    //                     if let Some(stdout) = self.read_stdout()? {
+    //                         event!(
+    //                             Level::INFO,
+    //                             channel = local_stdout.name(),
+    //                             stdout
+    //                         );
+    //                         // TODO:
+    //                         // LogChannel::log_line(
+    //                         //     self.stdout.get_producer().clone(),
+    //                         //     stdout,
+    //                         // );
+    //                     };
+    //                     if let Some(stderr) = self.read_stderr()? {
+    //                         event!(
+    //                             Level::ERROR,
+    //                             channel = local_stderr.name(),
+    //                             stderr
+    //                         );
+    //                         // TODO:
+    //                         // LogChannel::log_line(
+    //                         //     self.stderr.get_producer().clone(),
+    //                         //     stderr,
+    //                         // );
+    //                     };
+    //                 }
+    //                 ExecutableState::Stopped { .. } => running = false,
+    //             }
+    //         }
+    //         Ok(())
+    //     })
+    // }
 }
 
 // Start the child process
@@ -83,6 +245,10 @@ impl Executable {
 // Aurae makes the assumption that all Executables within a cell share the
 // same namespace isolation rules set up upon creation of the cell.
 fn exec(command: &mut Command) -> io::Result<Process> {
-    let child = command.current_dir("/").spawn()?;
+    let child = command
+        .current_dir("/")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
     Ok(Process::new_from_spawn(child))
 }

--- a/auraed/src/runtime/cell_service/executables/executable.rs
+++ b/auraed/src/runtime/cell_service/executables/executable.rs
@@ -4,21 +4,27 @@ use crate::logging::log_channel::LogChannel;
 use nix::sys::signal::SIGKILL;
 use nix::unistd::Pid;
 use std::ffi::OsString;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::{
     io,
     process::{Command, ExitStatus, Stdio},
 };
-use tracing::{event, Level};
+use tracing::{info, info_span};
+
+#[derive(Debug)]
+struct ExecutableInner {
+    name: ExecutableName,
+    description: String,
+    state: ExecutableState,
+    stdout: LogChannel,
+    stderr: LogChannel,
+}
 
 #[derive(Debug)]
 pub struct Executable {
-    pub name: ExecutableName,
-    pub description: String,
-    state: ExecutableState,
-    stdout: Arc<LogChannel>,
-    stderr: Arc<LogChannel>,
-    // TODO: log_thread: Option<std::thread::JoinHandle<io::Result<()>>>,
+    // TODO: consider RWLock?
+    inner: Arc<Mutex<ExecutableInner>>,
+    log_thread: Option<std::thread::JoinHandle<io::Result<()>>>,
 }
 
 #[derive(Debug)]
@@ -31,7 +37,7 @@ enum ExecutableState {
         program: OsString,
         #[allow(unused)]
         args: Vec<OsString>,
-        process: Process,
+        process: Arc<Mutex<Process>>,
     },
     Stopped(ExitStatus),
 }
@@ -39,33 +45,50 @@ enum ExecutableState {
 impl Executable {
     pub fn new<T: Into<ExecutableSpec>>(spec: T) -> Self {
         let ExecutableSpec { name, description, command } = spec.into();
-        let stdout = Arc::new(LogChannel::new(format!("{}::stdout", name)));
-        let stderr = Arc::new(LogChannel::new(format!("{}::stderr", name)));
-        Self {
-            name,
+        let state = ExecutableState::Init { command };
+        let inner = Arc::new(Mutex::new(ExecutableInner {
+            name: name.clone(),
             description,
-            state: ExecutableState::Init { command },
-            stdout,
-            stderr,
-            // TODO: log_thread: None,
-        }
+            state,
+            stdout: LogChannel::new(format!("{name}::stdout")),
+            stderr: LogChannel::new(format!("{name}::stderr")),
+        }));
+        Self { inner: inner.clone(), log_thread: Some(spawn_log_thread(inner)) }
+    }
+
+    pub fn name(&self) -> io::Result<ExecutableName> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        Ok(inner.name.clone())
+    }
+
+    pub fn description(&self) -> io::Result<String> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        Ok(inner.description.clone())
     }
 
     /// Starts the underlying process.
     /// Does nothing if [Executable] has previously been started.
     pub fn start(&mut self) -> io::Result<()> {
-        let ExecutableState::Init { command } = &mut self.state else {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        let ExecutableState::Init { command } = &mut inner.state else {
             return Ok(());
         };
 
         let process = exec(command)?;
 
-        // TODO: self.log_thread = Some(self.spawn_log_thread());
-
-        self.state = ExecutableState::Started {
+        inner.state = ExecutableState::Started {
             program: command.get_program().to_os_string(),
             args: command.get_args().map(|arg| arg.to_os_string()).collect(),
-            process,
+            process: Arc::new(Mutex::new(process)),
         };
 
         Ok(())
@@ -74,100 +97,103 @@ impl Executable {
     /// Stops the executable and returns the [ExitStatus].
     /// If the executable has never been started, returns [None].
     pub fn kill(&mut self) -> io::Result<Option<ExitStatus>> {
-        match &mut self.state {
-            ExecutableState::Init { .. } => Ok(None),
-            ExecutableState::Started { process, .. } => {
-                process.kill(Some(SIGKILL))?;
-                let exit_status = process.wait()?;
-                // TODO
-                //self.log_thread
-                //    .unwrap()
-                //    .join()
-                //    .expect("logging thread panicked")?;
-                for line in process.read_stdout()? {
-                    event!(
-                        Level::INFO,
-                        level = "info",
-                        channel = self.stdout.name(),
-                        line
-                    );
-                    LogChannel::log_line(
-                        self.stdout.get_producer().clone(),
-                        line.to_string(),
-                    );
+        let exit_status: Option<ExitStatus>;
+        {
+            let mut inner = self.inner.lock().map_err(|e| {
+                io::Error::new(io::ErrorKind::Other, e.to_string())
+            })?;
+            match &mut inner.state {
+                ExecutableState::Init { .. } => exit_status = None,
+                ExecutableState::Started { process, .. } => {
+                    let proc_status: ExitStatus;
+                    {
+                        let mut proc = process.lock().map_err(|e| {
+                            io::Error::new(io::ErrorKind::Other, e.to_string())
+                        })?;
+                        proc.kill(Some(SIGKILL))?;
+                        proc_status = proc.wait()?;
+                    }
+                    inner.state = ExecutableState::Stopped(proc_status);
+                    exit_status = Some(proc_status);
                 }
-                for line in process.read_stderr()? {
-                    event!(
-                        Level::INFO,
-                        level = "error",
-                        channel = self.stderr.name(),
-                        line
-                    );
-                    LogChannel::log_line(
-                        self.stderr.get_producer().clone(),
-                        line.to_string(),
-                    );
-                }
-                self.state = ExecutableState::Stopped(exit_status);
-                Ok(Some(exit_status))
-            }
-            ExecutableState::Stopped(exit_status) => Ok(Some(*exit_status)),
+                ExecutableState::Stopped(status) => exit_status = Some(*status),
+            };
         }
+        self.log_thread
+            .take()
+            .map(std::thread::JoinHandle::join)
+            .expect("thread panicked")
+            .expect("join log_thread")
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        Ok(exit_status)
     }
 
     /// Returns the [Pid] while [Executable] is running, otherwise returns [None].
-    pub fn pid(&self) -> Option<Pid> {
-        let ExecutableState::Started { process, .. } = &self.state else {
-            return None;
+    pub fn pid(&self) -> io::Result<Option<Pid>> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        let ExecutableState::Started { process, .. } = &inner.state else {
+            return Ok(None);
         };
+        let proc = process
+            .lock()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
-        Some(process.pid())
+        Ok(Some(proc.pid()))
     }
+}
 
-    // TODO:
-    // /// Spawns a thread that produces log lines while the [Executable] is running.
-    // fn spawn_log_thread(&mut self) -> std::thread::JoinHandle<io::Result<()>> {
-    //     let local_stdout = self.stdout.clone();
-    //     let local_stderr = self.stderr.clone();
-    //     std::thread::spawn(move || -> io::Result<()> {
-    //         let mut running = true;
-    //         while running {
-    //             match self.state {
-    //                 ExecutableState::Init { .. } => {}
-    //                 ExecutableState::Started { .. } => {
-    //                     // TODO: consider changing the pipes to use io::BufReader::new(file).lines()
-    //                     // and iterating over those lines here.
-    //                     if let Some(stdout) = self.read_stdout()? {
-    //                         event!(
-    //                             Level::INFO,
-    //                             channel = local_stdout.name(),
-    //                             stdout
-    //                         );
-    //                         // TODO:
-    //                         // LogChannel::log_line(
-    //                         //     self.stdout.get_producer().clone(),
-    //                         //     stdout,
-    //                         // );
-    //                     };
-    //                     if let Some(stderr) = self.read_stderr()? {
-    //                         event!(
-    //                             Level::ERROR,
-    //                             channel = local_stderr.name(),
-    //                             stderr
-    //                         );
-    //                         // TODO:
-    //                         // LogChannel::log_line(
-    //                         //     self.stderr.get_producer().clone(),
-    //                         //     stderr,
-    //                         // );
-    //                     };
-    //                 }
-    //                 ExecutableState::Stopped { .. } => running = false,
-    //             }
-    //         }
-    //         Ok(())
-    //     })
-    // }
+/// Spawns a thread that produces log lines while the [Executable] is running.
+fn spawn_log_thread(
+    inner: Arc<Mutex<ExecutableInner>>,
+) -> std::thread::JoinHandle<io::Result<()>> {
+    let local_inner = inner;
+    std::thread::spawn(move || -> io::Result<()> {
+        let mut running = true;
+        while running {
+            let inner = local_inner.lock().map_err(|e| {
+                io::Error::new(io::ErrorKind::Other, e.to_string())
+            })?;
+            let _span =
+                info_span!("running process", name = ?inner.name).entered();
+            match &inner.state {
+                ExecutableState::Init { .. } => {}
+                ExecutableState::Started { process, .. } => {
+                    let mut proc = process.lock().map_err(|e| {
+                        io::Error::new(io::ErrorKind::Other, e.to_string())
+                    })?;
+                    let lines = proc.read_stdout()?;
+                    for line in lines {
+                        info!(
+                            level = "info",
+                            channel = inner.stdout.name(),
+                            line
+                        );
+                        LogChannel::log_line(
+                            inner.stdout.get_producer().clone(),
+                            line.to_string(),
+                        );
+                    }
+                    let lines = proc.read_stderr()?;
+                    for line in lines {
+                        info!(
+                            level = "error",
+                            channel = inner.stderr.name(),
+                            line
+                        );
+                        LogChannel::log_line(
+                            inner.stderr.get_producer().clone(),
+                            line.to_string(),
+                        );
+                    }
+                }
+                ExecutableState::Stopped { .. } => running = false,
+            }
+        }
+        Ok(())
+    })
 }
 
 // Start the child process

--- a/auraed/src/runtime/cell_service/executables/executables.rs
+++ b/auraed/src/runtime/cell_service/executables/executables.rs
@@ -57,17 +57,18 @@ impl Executables {
             });
         }
 
+        let executable_name = executable_spec.name.clone();
         // `or_insert` will always insert as we've already assured ourselves that the key does not exist.
         let executable = self
             .cache
-            .entry(executable_spec.name.clone())
+            .entry(executable_name.clone())
             .or_insert_with(|| Executable::new(executable_spec));
 
         // TODO: if we fail to start, the exe remains in the cache and start cannot be called again
         // solving ^^ was a borrow checker fight and I (future-highway) lost this round.
         executable.start().map_err(|e| {
             ExecutablesError::FailedToStartExecutable {
-                executable_name: executable.name.clone(),
+                executable_name,
                 source: e,
             }
         })?;
@@ -90,9 +91,9 @@ impl Executables {
 
         let Some(exit_status) = exit_status else {
             // Exes that never started return None
-            let executable = self.cache.remove(executable_name).expect("exe in cache");
+            let _ = self.cache.remove(executable_name).expect("exe in cache");
             return Err(ExecutablesError::ExecutableNotFound {
-                executable_name: executable.name,
+                executable_name: executable_name.clone(),
             });
         };
 

--- a/auraescript/gen/runtime.ts
+++ b/auraescript/gen/runtime.ts
@@ -14,6 +14,9 @@ export interface FreePodRequest {
 export interface FreePodResponse {
 }
 
+export interface Pod {
+}
+
 export interface StartContainerRequest {
 }
 
@@ -24,6 +27,9 @@ export interface StopContainerRequest {
 }
 
 export interface StopContainerResponse {
+}
+
+export interface Container {
 }
 
 /** / The most primitive workload in Aurae, a standard executable process. */
@@ -227,6 +233,26 @@ export const FreePodResponse = {
   },
 };
 
+function createBasePod(): Pod {
+  return {};
+}
+
+export const Pod = {
+  fromJSON(_: any): Pod {
+    return {};
+  },
+
+  toJSON(_: Pod): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Pod>, I>>(_: I): Pod {
+    const message = createBasePod();
+    return message;
+  },
+};
+
 function createBaseStartContainerRequest(): StartContainerRequest {
   return {};
 }
@@ -303,6 +329,26 @@ export const StopContainerResponse = {
 
   fromPartial<I extends Exact<DeepPartial<StopContainerResponse>, I>>(_: I): StopContainerResponse {
     const message = createBaseStopContainerResponse();
+    return message;
+  },
+};
+
+function createBaseContainer(): Container {
+  return {};
+}
+
+export const Container = {
+  fromJSON(_: any): Container {
+    return {};
+  },
+
+  toJSON(_: Container): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Container>, I>>(_: I): Container {
+    const message = createBaseContainer();
     return message;
   },
 };

--- a/examples/cells_output.ts
+++ b/examples/cells_output.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env auraescript
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+import * as helpers from "../auraescript/gen/helpers.ts";
+import * as runtime from "../auraescript/gen/runtime.ts";
+
+let cells = new runtime.CellServiceClient();
+
+// [ Allocate ]
+let allocated = await cells.allocate(<runtime.AllocateCellRequest>{
+    cell: runtime.Cell.fromPartial({
+        cpuQuota: 400 * (10 ** 3), // 0.4 seconds in microseconds
+        cpuShares: 2, // Percentage of CPUs
+        name: "echo-cell",
+    })
+});
+//helpers.print(allocated)
+
+// [ Start ]
+let started_out = await cells.start(<runtime.StartExecutableRequest>{
+    cellName: "echo-cell",
+    executable: runtime.Executable.fromPartial({
+        command: "/usr/bin/echo 'hello world'",
+        description: "outputs a message to stdout",
+        name: "echo-stdout"
+    })
+})
+//helpers.print(started_out)
+
+// [ Start ]
+let started_err = await cells.start(<runtime.StartExecutableRequest>{
+    cellName: "echo-cell",
+    executable: runtime.Executable.fromPartial({
+        command: "/usr/bin/echo 'hello world' 1>&2",
+        description: "outputs a message to stderr",
+        name: "echo-stderr"
+    })
+})
+
+// [ Stop ]
+let stopped_out = await cells.stop(<runtime.StopExecutableRequest>{
+    cellName: "echo-cell",
+    executableName: "echo-stdout",
+})
+// [ Stop ]
+let stopped_err = await cells.stop(<runtime.StopExecutableRequest>{
+    cellName: "echo-cell",
+    executableName: "echo-stderr",
+})
+//helpers.print(stopped)
+
+// [ Free ]
+let freed = await cells.free(<runtime.FreeCellRequest>{
+    cellName: "echo-cell"
+});
+//helpers.print(freed)


### PR DESCRIPTION
Fixes #173 

In the case of a spawned `Child`, this reads stdout directly.  In the case of a cloned `Process`, this gets the stdout or stderr file descriptor from the process and reads from it.  `Process` is responsible for reading the stdout or stderr.

The `Executable` is responsible for reading the output is read in batches of lines in a thread.

The output is then sent for both tracing output in a "running process" span and to new `LogChannel`s that are created when an `Executable` is created.  this latter will allow the `ObserveService` to expose the logs to the user, though this hasn't been implemented.  The span includes the name of the executable that's running.

The output is always logged at `INFO` level, but with a `level` (and `channel`) field indicating whether it came from stdout or stderr. 