### PR TITLE
refactor: Add build GHA image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.cache
+.dockerignore
+.github*
+.gitignore
+.idea*
+Dockerfile
+docs/crate/*
+target*

--- a/.github/workflows/build-with-containers.yml
+++ b/.github/workflows/build-with-containers.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username:  ${{ github.repository_owner }}
+          username:  ${{ github.actor }}
           password:  ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Docker Build Image
@@ -70,7 +70,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository }}/aurae-builder:${{ needs.build-container.outputs.tag }}
       credentials:
-        username:  ${{ github.repository_owner }}
+        username:  ${{ github.actor }}
         password:  ${{ secrets.GITHUB_TOKEN }}
       options: --cpus 1
     steps:
@@ -101,7 +101,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository }}/aurae-builder:${{ needs.build-container.outputs.tag }}
       credentials:
-        username:  ${{ github.repository_owner }}
+        username:  ${{ github.actor }}
         password:  ${{ secrets.GITHUB_TOKEN }}
       options: --cpus 1
     steps:

--- a/.github/workflows/build-with-containers.yml
+++ b/.github/workflows/build-with-containers.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username:  ${{ github.actor }}
+          username:  ${{ github.repository_owner }}
           password:  ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Docker Build Image
@@ -70,7 +70,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository }}/aurae-builder:${{ needs.build-container.outputs.tag }}
       credentials:
-        username:  ${{ github.actor }}
+        username:  ${{ github.repository_owner }}
         password:  ${{ secrets.GITHUB_TOKEN }}
       options: --cpus 1
     steps:
@@ -101,7 +101,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository }}/aurae-builder:${{ needs.build-container.outputs.tag }}
       credentials:
-        username:  ${{ github.actor }}
+        username:  ${{ github.repository_owner }}
         password:  ${{ secrets.GITHUB_TOKEN }}
       options: --cpus 1
     steps:

--- a/.github/workflows/build-with-containers.yml
+++ b/.github/workflows/build-with-containers.yml
@@ -1,0 +1,124 @@
+name: Build
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+env:
+  CARGO_TERM_COLOR: always
+  CACHE_VERSION: v2
+  RUSTUP_TOOLCHAIN: stable
+jobs:
+  build-container:
+    name: Build docker image
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ format('{0}-{1}', github.ref, github.job) }}
+    outputs:
+        tag: ${{ steps.image-tag.outputs.tag}}
+    steps:
+      - uses: actions/checkout@v3
+      - id: image-tag
+        run: |
+          echo "tag=${{ hashFiles('**docker/Dockerfile.build', '**/Cargo.lock') }}-${{env.CACHE_VERSION}}" >> $GITHUB_OUTPUT
+     
+      - name: Check if docker build needs to run
+        uses: actions/cache@v3
+        id: check-change
+        with:
+          path: |
+            docker/Dockerfile.build
+          key: build-image-marker-${{ runner.os }}-${{ hashFiles('**docker/Dockerfile.build', '**/Cargo.lock') }}-${{env.CACHE_VERSION}}
+
+      - name: Set up Docker Buildx
+        if: steps.check-change.outputs.cache-hit != 'true'
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+
+      - name: Login to Github Docker Registry
+        if: steps.check-change.outputs.cache-hit != 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username:  ${{ github.actor }}
+          password:  ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Docker Build Image
+        id: build
+        if: steps.check-change.outputs.cache-hit != 'true'
+        uses: docker/build-push-action@v2
+        timeout-minutes: 15
+        with:
+          context: .
+          file: docker/Dockerfile.build
+          push: true
+          pull: true
+          build-args: RUSTUP_TOOLCHAIN:${{env.RUSTUP_TOOLCHAIN}}
+          tags: ghcr.io/${{ github.repository }}/aurae-builder:latest,ghcr.io/${{ github.repository }}/aurae-builder:${{ steps.image-tag.outputs.tag}}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-docs-with-container:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    needs: build-container
+    container:
+      image: ghcr.io/${{ github.repository }}/aurae-builder:${{ needs.build-container.outputs.tag }}
+      credentials:
+        username:  ${{ github.actor }}
+        password:  ${{ secrets.GITHUB_TOKEN }}
+      options: --cpus 1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: build-docs-test-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-${{env.CACHE_VERSION}}
+      
+      - name: Check docs (make check-docs)
+        run: |
+          make check-docs
+
+      - name: Docs (make docs)
+        run: |
+          make docs
+
+  build:
+    name: Build (lint, compile, test)
+    runs-on: ubuntu-latest
+    needs: build-container
+    timeout-minutes: 20
+    container:
+      image: ghcr.io/${{ github.repository }}/aurae-builder:${{ needs.build-container.outputs.tag }}
+      credentials:
+        username:  ${{ github.actor }}
+        password:  ${{ secrets.GITHUB_TOKEN }}
+      options: --cpus 1
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: build-lint-test-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-${{env.CACHE_VERSION}}
+
+      - name: Build (make build)
+        run: make build
+
+      - name: Lint (make lint)
+        run: make lint
+
+      - name: Tests (make test)
+        run: make testci

--- a/.github/workflows/build-with-containers.yml
+++ b/.github/workflows/build-with-containers.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: write
+  packages: write
 env:
   CARGO_TERM_COLOR: always
   CACHE_VERSION: v2
@@ -13,9 +16,6 @@ jobs:
   build-container:
     name: Build docker image
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     concurrency:
       group: ${{ format('{0}-{1}', github.ref, github.job) }}
     outputs:
@@ -66,9 +66,6 @@ jobs:
   build-docs-with-container:
     name: Build Docs
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     needs: build-container
     container:
       image: ghcr.io/${{ github.repository }}/aurae-builder:${{ needs.build-container.outputs.tag }}
@@ -99,9 +96,6 @@ jobs:
   build:
     name: Build (lint, compile, test)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     needs: build-container
     timeout-minutes: 20
     container:

--- a/.github/workflows/build-with-containers.yml
+++ b/.github/workflows/build-with-containers.yml
@@ -13,6 +13,9 @@ jobs:
   build-container:
     name: Build docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     concurrency:
       group: ${{ format('{0}-{1}', github.ref, github.job) }}
     outputs:
@@ -63,6 +66,9 @@ jobs:
   build-docs-with-container:
     name: Build Docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs: build-container
     container:
       image: ghcr.io/${{ github.repository }}/aurae-builder:${{ needs.build-container.outputs.tag }}
@@ -93,6 +99,9 @@ jobs:
   build:
     name: Build (lint, compile, test)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs: build-container
     timeout-minutes: 20
     container:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@
 branch       ?=  main
 message      ?=  Default commit message. Aurae Runtime environment.
 cargo         =  cargo
+oci           =  docker
 
 # Configuration Options
 export GIT_PAGER = cat
@@ -159,3 +160,6 @@ start:
 help:  ## Show help messages for make targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: oci-build
+oci-build: ## Build the aurae/auraed OCI images
+	$(oci) buildx build -t $(tag) -f $(ocifile) $(flags) .

--- a/auraed/Makefile
+++ b/auraed/Makefile
@@ -63,3 +63,7 @@ include hack/hack.mk
 .PHONY: help
 help:  ## Show help messages for make targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: oci-build
+oci-build: ## Build the aurae/auraed OCI images
+	$(oci) buildx build -t $(tag) -f $(ocifile) $(flags) .

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,0 +1,59 @@
+# syntax = docker/dockerfile:1.4
+FROM bitnami/minideb:latest as main
+
+## Define ARGs
+ARG RUSTUP_TOOLCHAIN=stable
+ARG BUF_VERSION=1.11.0
+ARG VALE_VERSION=2.21.3
+ARG PROTOC_VERSION=1.5.1
+
+## Install packages
+RUN  apt-get update && \
+    install_packages  --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    libclang-dev \
+    libdbus-1-dev \
+    libseccomp-dev \
+    protobuf-compiler \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+## Setup protoc-gen-doc
+RUN curl  -O -J -L https://github.com/pseudomuto/protoc-gen-doc/releases/download/v${PROTOC_VERSION}/protoc-gen-doc_${PROTOC_VERSION}_linux_amd64.tar.gz && \
+    tar -xzf protoc-gen-doc_1.5.1_linux_amd64.tar.gz && \
+    chmod +x protoc-gen-doc && \
+    mv protoc-gen-doc /usr/local/bin/protoc-gen-doc && \
+    rm protoc-gen-doc_1.5.1_linux_amd64.tar.gz
+
+## Setup Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUSTUP_TOOLCHAIN}
+ENV PATH=$PATH:/root/.cargo/bin
+RUN rustup component add clippy
+
+## Setup Buf
+RUN curl -sSL \
+    "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-$(uname -s)-$(uname -m)" \
+    -o "/usr/local/bin/buf" && \
+    chmod +x "/usr/local/bin/buf"
+
+## Setup Vale
+RUN curl -sSl -J -L "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" \
+    -o vale.tar.gz && \
+    tar -xvzf vale.tar.gz -C bin && \
+    mv bin/vale /usr/local/bin/vale && \
+    rm vale.tar.gz
+
+WORKDIR /app
+
+FROM main AS planner
+RUN cargo install cargo-chef
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+RUN cargo chef cook --recipe-path recipe.json
+
+FROM main as builder
+COPY --from=planner /root/.cargo/bin /root/.cargo/bin
+COPY --from=planner /root/.cargo/registry/index/ /root/.cargo/registry/index/
+COPY --from=planner /root/.cargo/registry/cache/ /root/.cargo/registry/cache/

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,6 +1,8 @@
 # syntax = docker/dockerfile:1.4
 FROM bitnami/minideb:latest as main
 
+LABEL org.opencontainers.image.source https://github.com/aurae-runtime/aurae
+
 ## Define ARGs
 ARG RUSTUP_TOOLCHAIN=stable
 ARG BUF_VERSION=1.11.0


### PR DESCRIPTION
I took another whack at [this](https://github.com/aurae-runtime/aurae/issues/79) using a few different methods. The time to run is still a bit longer than native GHA jobs, but with a self-hosted runner I think it would be pretty similar.

I'm building the image as the first step in the pipeline, then using that image to run the jobs on downstream. I have introduced [cargo-chef](https://crates.io/crates/cargo-chef) to package the dependencies, without needing to compile the code itself.

Using minideb we launch a container that has the rust requirements (but without extras like cargo-chef). This runs the actual make steps, and uses native GHA caching for the rust modules.

I would be happy to setup and own a self-hosted runner and [docker registry](https://github.com/aurae-runtime/aurae/issues/78). I'm happy to chat about that in discord too (kuxaku) :)

Most of the build layers should cache across branches too (using buildkits native GHA cache), so the first time it runs should be the longest.

Biggest Risks:
- I got the caching wrong and the pipeline doesn't have correct dependencies someplace along the test/build process
- The build times are longer, impacting developer feedback times

Out of scope:
- I did not apply the docker image to the `deploy` step yet.

I kept the original two GHA jobs in the pipeline for reference. If/when this gets merged they can be ran alongside for a bit to ensure its working, or deleted in a second PR.