### PR TITLE
Docs improvements

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -31,6 +31,13 @@ jobs:
           cp protoc-gen-doc /usr/local/bin/protoc-gen-doc
           cd ../
           rm -rf src
+      - name: Check documenation
+        run: |
+          wget --output-document=vale.tar.gz https://github.com/errata-ai/vale/releases/download/v2.21.3/vale_2.21.3_Linux_64-bit.tar.gz
+          mkdir bin && tar -xvzf vale.tar.gz -C bin
+          export PATH="$PWD/bin:$PATH"
+
+          make check-docs
       - name: Build documentation
         run: |
           make docs

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,9 @@
+StylesPath = .vale
+
+MinAlertLevel = warning
+
+# inline-level HTML tags to ignore
+IgnoredScopes = code, tt, a, h1, h2, h3, h4
+
+[*.md]
+BasedOnStyles = Aurae

--- a/.vale/Aurae/CaseSensitiveTerms.yml
+++ b/.vale/Aurae/CaseSensitiveTerms.yml
@@ -1,0 +1,18 @@
+---
+extends: substitution
+ignorecase: false
+level: error
+message: Use '%s' rather than '%s'.
+action:
+  name: replace
+swap:
+  aurae: Aurae
+  Auraed: auraed
+  CGroup|c group: cgroup
+  dns: DNS
+  gid: GID
+  makefile: Makefile
+  OS|Operating System: operating system
+  pid: PID
+  uid: UID
+  unix: Unix

--- a/.vale/Aurae/Spelling.yml
+++ b/.vale/Aurae/Spelling.yml
@@ -1,0 +1,27 @@
+---
+extends: spelling
+level: warning
+message: "Use correct American English spelling. Did you really mean '%s'?"
+# A "filter" is a case-sensitive regular expression specifying words to ignore during spell checking.
+# Spelling rule applies to individual words
+filters:
+  - '[eE]num'
+  - API
+  - Aurae
+  - auraed
+  - authn
+  - authz
+  - cgroup
+  - composable
+  - loopback
+  - Makefile
+  - namespace
+  - protobuf
+  - RPC
+  - runtime
+  - seccomp
+  - stdlib
+  - systemd
+  - toolchain
+  - untrusted
+  - virtualized

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ auraed: proto ## Initialize and compile auraed
 	@$(cargo) clippy -p auraed
 	@$(cargo) install --path ./auraed --debug --force
 
+.PHONY: check-docs
+check-docs: # spell checking
+	@vale --no-wrap --glob='!docs/stdlib/v0/*' ./docs
+
 .PHONY: docs
 docs: crate stdlibdocs ## Assemble all the /docs for the website locally.
 	cp -rv README.md docs/index.md # Special copy for the main README

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Aurae is a free and open source Rust project which houses a memory-safe systems runtime daemon built specifically for enterprise distributed systems called `auraed`.
 
-The `auraed` daemon can be run as a pid 1 on a Linux kernel and manages containers, virtual machines, and spawning short-lived nested virtual instances of itself for an additional layer of isolation.
+The `auraed` daemon can be run as a PID 1 on a Linux kernel and manages containers, virtual machines, and spawning short-lived nested virtual instances of itself for an additional layer of isolation.
 
 ### Mission
 
@@ -34,7 +34,7 @@ Aurae offers a runtime API which is capable of managing:
 
 ### Auraed
 
-Think of [auraed](https://github.com/aurae-runtime/aurae/tree/main/auraed) as a pid 1 init machine daemon with a scope similar to [systemd](https://www.freedesktop.org/wiki/Software/systemd/) and functionality similar to [containerd](https://github.com/containerd/containerd) and [firecracker](https://github.com/firecracker-microvm/firecracker).
+Think of [auraed](https://github.com/aurae-runtime/aurae/tree/main/auraed) as a PID 1 init machine daemon with a scope similar to [systemd](https://www.freedesktop.org/wiki/Software/systemd/) and functionality similar to [containerd](https://github.com/containerd/containerd) and [firecracker](https://github.com/firecracker-microvm/firecracker).
 
 ### Authentication
 

--- a/api/README.md
+++ b/api/README.md
@@ -45,7 +45,7 @@ In protobuf terms a function is a [remote procedure call (RPC)](https://develope
 
 ### API Definition Convention
 
-Generally follow [this style guide](https://developers.google.com/protocol-buffers/docs/style) in the proto files.
+Generally follow [this style guide](https://developers.google.com/protocol-buffers/docs/style) in the `.proto` files.
 
 It is short, but the main points are:
 
@@ -93,5 +93,5 @@ A notable exception to the public specification above is the Aurae projects pref
 
 The traditional convention that is meant to reduce the likelihood of future breaking changes and ease the creation of macros for generating code:
 
-- rpc methods (e.g., `StartWidget`) should have dedicated request and response messages named `StartWidgetResponse` and `StartWidgetResponse`
-- objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetRequest`, etc style methods.
+- RPC methods (e.g., `StartWidget`) should have dedicated request and response messages named `StartWidgetResponse` and `StopWidgetResponse`
+- Objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetRequest`, etc style methods.

--- a/docs/auraed/index.md
+++ b/docs/auraed/index.md
@@ -2,7 +2,7 @@
 
 The Aurae Daemon (auraed) is the main daemon that powers Aurae. 
 
-The Aurae Daemon runs as a gRPC server which listens over a unix domain socket by default.
+The Aurae Daemon runs as a gRPC server which listens over a Unix domain socket by default.
 
 ``` 
 /var/run/aurae/aurae.sock

--- a/docs/blog/2022-10-24-aurae-cells.md
+++ b/docs/blog/2022-10-24-aurae-cells.md
@@ -73,7 +73,7 @@ I often say that cgroups are "vertical" resource slices and namespaces are "hori
 
 ## Systemd Slices
 
-By default, systemd schedules all of its workloads in their own cgroup with access to the same namespaces as pid 1 on the system. These workloads are called [services](https://www.freedesktop.org/software/systemd/man/systemd.service.html) or units.
+By default, systemd schedules all of its workloads in their own cgroup with access to the same namespaces as PID 1 on the system. These workloads are called [services](https://www.freedesktop.org/software/systemd/man/systemd.service.html) or units.
 
 Interestingly enough, Kubernetes also leverages systemd slices. You can usually see both systemd slices (`system.slice`) and Kubernetes pods (`kubepods.slice`) running side-by-side by exploring [/sys](https://man7.org/linux/man-pages/man5/sysfs.5.html) or `sysfs(5)` on your system. There are usually other cgroups running there as well. 
 
@@ -132,7 +132,7 @@ Regardless of if an administrator is executing a basic process, or a container: 
 Taking a step back from containerization we also understand that many enterprise users will need to execute untrusted code at scale.
 Aurae additionally acts as a lightweight virtualization hypervisor and meta-data service in addition to being a cgroup broker.
 
-Each instance of Aurae comes with its own running pid 1 daemon called `auraed`.
+Each instance of Aurae comes with its own running PID 1 daemon called `auraed`.
 
 ![cells](/assets/img/blog-instance.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 
 Aurae is a free and open source Rust project which houses a memory-safe systems runtime daemon built specifically for enterprise distributed systems called `auraed`.
 
-The `auraed` daemon can be run as a pid 1 on a Linux kernel and manages containers, virtual machines, and spawning short-lived nested virtual instances of itself for an additional layer of isolation.
+The `auraed` daemon can be run as a PID 1 on a Linux kernel and manages containers, virtual machines, and spawning short-lived nested virtual instances of itself for an additional layer of isolation.
 
 ### Mission
 
@@ -34,7 +34,7 @@ Aurae offers a runtime API which is capable of managing:
 
 ### Auraed
 
-Think of [auraed](https://github.com/aurae-runtime/aurae/tree/main/auraed) as a pid 1 init machine daemon with a scope similar to [systemd](https://www.freedesktop.org/wiki/Software/systemd/) and functionality similar to [containerd](https://github.com/containerd/containerd) and [firecracker](https://github.com/firecracker-microvm/firecracker).
+Think of [auraed](https://github.com/aurae-runtime/aurae/tree/main/auraed) as a PID 1 init machine daemon with a scope similar to [systemd](https://www.freedesktop.org/wiki/Software/systemd/) and functionality similar to [containerd](https://github.com/containerd/containerd) and [firecracker](https://github.com/firecracker-microvm/firecracker).
 
 ### Authentication
 

--- a/docs/stdlib/index.md
+++ b/docs/stdlib/index.md
@@ -45,7 +45,7 @@ In protobuf terms a function is a [remote procedure call (RPC)](https://develope
 
 ### API Definition Convention
 
-Generally follow [this style guide](https://developers.google.com/protocol-buffers/docs/style) in the proto files.
+Generally follow [this style guide](https://developers.google.com/protocol-buffers/docs/style) in the `.proto` files.
 
 It is short, but the main points are:
 
@@ -93,5 +93,5 @@ A notable exception to the public specification above is the Aurae projects pref
 
 The traditional convention that is meant to reduce the likelihood of future breaking changes and ease the creation of macros for generating code:
 
-- rpc methods (e.g., `StartWidget`) should have dedicated request and response messages named `StartWidgetResponse` and `StopWidgetResponse`
-- objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetRequest`, etc style methods.
+- RPC methods (e.g., `StartWidget`) should have dedicated request and response messages named `StartWidgetResponse` and `StopWidgetResponse`
+- Objects (e.g., `Widget`) should be embedded directly into their corresponding `StartWidgetRequest`, `StopWidgetRequest`, etc style methods.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: "Aurae Runtime"
 site_url: "https://aurae.io"
 repo_url: "https://github.com/aurae-runtime/aurae"
-edit_uri: "edit/main/"
+edit_uri: "edit/main/docs/"
 
 nav:
   - Home: index.md


### PR DESCRIPTION
This PR does two things:

1. Fixes the "Edit this page" link that mkdocs provides for convenience:

![image](https://user-images.githubusercontent.com/1732128/210016991-82d54334-7904-436f-b110-3dcd44fab403.png)

2. Adds vale (a _syntax-aware linter for prose_) as tool  to ensure a certain level of consistency in the docs.

Let me know if you're fine with the addition - as it is now it would cause the `Documentation` workflow to fail if a change in the docs violates the style that vale enforces.