### PR TITLE
Restructure proto files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ stdlibdocs:
 	$(error "No /usr/local/bin/protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
 else
 stdlibdocs:
-	protoc --plugin=/usr/local/bin/protoc-gen-doc -I api/v0 --doc_out=docs/stdlib/v0 --doc_opt=markdown,index.md:Ignore* api/v0/*.proto
+	protoc --plugin=/usr/local/bin/protoc-gen-doc -I api/v0/runtime -I api/v0/schedule -I api/v0/observe --doc_out=docs/stdlib/v0 --doc_opt=markdown,index.md:Ignore* api/v0/*/*.proto
 endif
 
 crate: ## Build the crate (documentation)

--- a/api/v0/observe/observe.proto
+++ b/api/v0/observe/observe.proto
@@ -32,8 +32,6 @@ syntax = "proto3";
 
 package aurae.observe.v0;
 
-option go_package = "github.com/aurae-runtime/client-go/pkg/api/v0/observe";
-
 enum LogChannelType {
   LOG_CHANNEL_TYPE_UNSPECIFIED = 0;
   LOG_CHANNEL_TYPE_STDOUT = 1;

--- a/api/v0/runtime/runtime.proto
+++ b/api/v0/runtime/runtime.proto
@@ -32,8 +32,6 @@ syntax = "proto3";
 
 package aurae.runtime.v0;
 
-option go_package = "github.com/aurae-runtime/client-go/pkg/api/v0/runtime";
-
 /// Runtime
 /// ===
 ///

--- a/api/v0/schedule/schedule.proto
+++ b/api/v0/schedule/schedule.proto
@@ -32,6 +32,4 @@ syntax = "proto3";
 
 package aurae.schedule.v0;
 
-option go_package = "github.com/aurae-runtime/client-go/pkg/api/v0/schedule";
-
 // TODO Schedule subsystem

--- a/auraescript/macros/src/ops.rs
+++ b/auraescript/macros/src/ops.rs
@@ -166,7 +166,7 @@ fn typescript_generator(input: &OpsGeneratorInput) {
 
     let ts_path = {
         let mut out_dir = gen_dir.clone();
-        out_dir.push(format!("v0/{module}.ts"));
+        out_dir.push(format!("v0/{module}/{module}.ts"));
         out_dir
     };
 


### PR DESCRIPTION
The previous structure was incompatible with the gRPC Go plugin for the buf tool since the generated Go code would get generated into a single directory with each file having a different package.

```
api/v0/observe.proto -> api/v0/observe/observe.proto
api/v0/schedule.proto -> api/v0/schedule/schedule.proto
api/v0/runtime.proto -> api/v0/runtime/runtime.proto
```