### PR TITLE
Make `Executable` async using `tokio::process::Command`

### DIFF
--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -62,7 +62,7 @@ simplelog = "0.12.0"
 sys-mount = "2.0.1"
 syslog = "6.0.1"
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "fs", "rt-multi-thread", "sync", "signal"] }
+tokio = { workspace = true, features = ["macros", "fs", "rt-multi-thread", "sync", "signal", "process"] }
 tokio-stream = { version = "0.1", features = ["net", "sync"] }
 tonic = { workspace = true, features = ["tls"] }
 tracing = { workspace = true, features = ["log"] }

--- a/auraed/src/logging/log_channel.rs
+++ b/auraed/src/logging/log_channel.rs
@@ -31,64 +31,40 @@
 // @todo @krisnova remove this once logging is futher along
 #![allow(dead_code)]
 //
+use super::get_timestamp_sec;
 use aurae_proto::observe::LogItem;
 use tokio::sync::broadcast::{self, Receiver, Sender};
-use tracing::error;
-
-use super::get_timestamp_sec;
 
 /// Abstraction Layer for one log generating entity
 /// LogChannel provides channels between Log producers and log consumers
-#[derive(Debug)]
-pub struct LogChannel {
-    producer: Sender<LogItem>,
-    name: String,
+#[derive(Clone, Debug)]
+pub(crate) struct LogChannel {
+    pub name: String,
+    tx: Sender<LogItem>,
 }
 
 impl LogChannel {
     /// Constructor creating the channel for log communication
     pub fn new(name: String) -> LogChannel {
         // TODO: decide for a cap. 40 is arbitrary
-        let (producer, _) = broadcast::channel(40);
-        LogChannel { producer, name }
-    }
-
-    /// Getter for the name
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Getter for producer channel
-    pub fn get_producer(&self) -> Sender<LogItem> {
-        self.producer.clone()
+        let (tx, _) = broadcast::channel(40);
+        LogChannel { name, tx }
     }
 
     /// Getter for consumer channel
-    pub fn get_consumer(&self) -> Receiver<LogItem> {
-        self.producer.subscribe()
+    pub fn subscribe(&self) -> Receiver<LogItem> {
+        self.tx.subscribe()
     }
 
     /// Wrapper that sends a log line to the channel
-    pub fn log_line(producer: Sender<LogItem>, line: String) {
+    pub fn send(&self, line: String) {
         // send returns an Err if there are no receivers. We ignore that.
-        let _ = producer.send(LogItem {
+        let _ = self.tx.send(LogItem {
             channel: "unknown".to_string(),
             line,
             // TODO: milliseconds type in protobuf requires 128bit type
             timestamp: get_timestamp_sec(),
         });
-    }
-
-    // Receives a message from the channel
-    // multiple consumer possible
-    async fn consume_line(consumer: &mut Receiver<LogItem>) -> Option<LogItem> {
-        match consumer.recv().await {
-            Ok(val) => Some(val),
-            Err(e) => {
-                error!("Error: {:?}", e);
-                None
-            }
-        }
     }
 }
 
@@ -111,23 +87,22 @@ mod tests {
     #[tokio::test]
     async fn test_ringbuffer_queue() {
         init_logging();
-        let lrb = LogChannel::new("Test".into());
-        let prod = lrb.get_producer();
-        let mut consumer = lrb.get_consumer();
+        let channel = LogChannel::new("Test".into());
+        let mut rx = channel.subscribe();
 
-        LogChannel::log_line(prod.clone(), "hello".into());
-        LogChannel::log_line(prod.clone(), "aurae".into());
-        LogChannel::log_line(prod.clone(), "bye".into());
+        channel.send("hello".into());
+        channel.send("aurae".into());
+        channel.send("bye".into());
 
-        let cur_item = LogChannel::consume_line(&mut consumer).await;
+        let cur_item = rx.recv().await.ok();
         assert!(cur_item.is_some());
         assert_eq!(cur_item.unwrap().line, "hello".to_string());
 
-        let cur_item = LogChannel::consume_line(&mut consumer).await;
+        let cur_item = rx.recv().await.ok();
         assert!(cur_item.is_some());
         assert_eq!(cur_item.unwrap().line, "aurae".to_string());
 
-        let cur_item = LogChannel::consume_line(&mut consumer).await;
+        let cur_item = rx.recv().await.ok();
         assert!(cur_item.is_some());
         assert_eq!(cur_item.unwrap().line, "bye".to_string());
     }

--- a/auraed/src/logging/log_channel.rs
+++ b/auraed/src/logging/log_channel.rs
@@ -60,7 +60,7 @@ impl LogChannel {
     pub fn send(&self, line: String) {
         // send returns an Err if there are no receivers. We ignore that.
         let _ = self.tx.send(LogItem {
-            channel: "unknown".to_string(),
+            channel: self.name.clone(),
             line,
             // TODO: milliseconds type in protobuf requires 128bit type
             timestamp: get_timestamp_sec(),

--- a/auraed/src/observe/mod.rs
+++ b/auraed/src/observe/mod.rs
@@ -46,7 +46,7 @@ use crate::logging::log_channel::LogChannel;
 
 /// The server side implementation of the ObserveService subsystem.
 #[derive(Debug)]
-pub struct ObserveServiceServer {
+pub(crate) struct ObserveServiceServer {
     aurae_logger: Arc<LogChannel>,
     sub_process_consumer_list: Vec<Receiver<LogItem>>,
 }
@@ -76,7 +76,7 @@ impl ObserveService for ObserveServiceServer {
     ) -> Result<Response<Self::GetAuraeDaemonLogStreamStream>, Status> {
         let (tx, rx) = mpsc::channel::<Result<LogItem, Status>>(4);
 
-        let mut log_consumer = self.aurae_logger.get_consumer();
+        let mut log_consumer = self.aurae_logger.subscribe();
 
         // TODO: error handling. Warning: recursively logging if error message is also send to this grpc api endpoint
         //  .. thus disabled logging here.

--- a/auraed/src/runtime/cell_service/cell_service.rs
+++ b/auraed/src/runtime/cell_service/cell_service.rs
@@ -192,6 +192,7 @@ impl CellService {
             let mut executables = self.executables.lock().await;
             let _exit_status = executables
                 .stop(&executable_name)
+                .await
                 .map_err(CellsServiceError::ExecutablesError)?;
 
             Ok(Response::new(CellServiceStopResponse::default()))

--- a/auraed/src/runtime/cell_service/executables/mod.rs
+++ b/auraed/src/runtime/cell_service/executables/mod.rs
@@ -32,7 +32,7 @@ pub use error::{ExecutablesError, Result};
 pub use executable::Executable;
 pub use executable_name::ExecutableName;
 pub use executables::Executables;
-use std::process::Command;
+use tokio::process::Command;
 
 pub mod auraed;
 mod error;

--- a/auraed/src/runtime/cell_service/validation.rs
+++ b/auraed/src/runtime/cell_service/validation.rs
@@ -8,7 +8,7 @@ use aurae_proto::runtime::{
 };
 use std::collections::VecDeque;
 use std::ffi::OsString;
-use std::process::Command;
+use tokio::process::Command;
 use validation::{ValidatedField, ValidatedType, ValidationError};
 use validation_macros::ValidatedType;
 
@@ -240,7 +240,7 @@ impl From<ValidatedExecutable> for super::executables::ExecutableSpec {
 
         // We are checking that command has an arg to assure ourselves that `command.arg`
         // mutates command, and is not making a clone to return
-        assert_eq!(c.get_args().len(), 2);
+        assert_eq!(c.as_std().get_args().len(), 2);
 
         Self { name, command: c, description }
     }


### PR DESCRIPTION
`Executable` now uses `tokio::process::Command` for its async abilities. It no longer uses the `Process` enum that we have in the module as it seems like it's more trouble then it's worth.

`NestedAuraed` is still synchronous as I would rather see how that evolves to fill our needs prior to making it async. It also still uses `Process`, but there is probably no reason for `Process` to exist separately so it will probably be incorporated into `NestedAuraed`.

I also refactored LogChannel into a more expected structure.