### PR TITLE
Remove cached cargo deps from the docker image

### DIFF
--- a/.github/workflows/build-with-containers.yml
+++ b/.github/workflows/build-with-containers.yml
@@ -56,7 +56,7 @@ jobs:
           context: .
           file: docker/Dockerfile.build
           push: true
-          pull: true
+          build-args: CACHE_VERSION=${{env.CACHE_VERSION}}
           tags: ghcr.io/${{ github.repository }}/aurae-builder:latest,ghcr.io/${{ github.repository }}/aurae-builder:${{ steps.image-tag.outputs.tag}}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-with-containers.yml
+++ b/.github/workflows/build-with-containers.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - id: image-tag
         run: |
-          echo "tag=${{ hashFiles('**docker/Dockerfile.build', '**/Cargo.lock') }}-${{env.CACHE_VERSION}}" >> $GITHUB_OUTPUT
+          echo "tag=${{ hashFiles('**docker/Dockerfile.build') }}-${{env.CACHE_VERSION}}" >> $GITHUB_OUTPUT
      
       - name: Check if docker build needs to run
         uses: actions/cache@v3
@@ -31,7 +31,7 @@ jobs:
         with:
           path: |
             docker/Dockerfile.build
-          key: build-image-marker-${{ runner.os }}-${{ hashFiles('**docker/Dockerfile.build', '**/Cargo.lock') }}-${{env.CACHE_VERSION}}
+          key: build-image-marker-${{ runner.os }}-${{ hashFiles('**docker/Dockerfile.build') }}-${{env.CACHE_VERSION}}
 
       - name: Set up Docker Buildx
         if: steps.check-change.outputs.cache-hit != 'true'

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,9 +1,9 @@
 # syntax = docker/dockerfile:1.4
 FROM rust:1-slim-bullseye as main
-
 LABEL org.opencontainers.image.source https://github.com/aurae-runtime/aurae
 
 ## Define ARGs
+ARG CACHE_VERSION=v0
 ARG BUF_VERSION=1.11.0
 ARG VALE_VERSION=2.21.3
 ARG PROTOC_VERSION=1.5.1
@@ -25,10 +25,10 @@ RUN rustup component add clippy
 
 ## Setup protoc-gen-doc
 RUN curl  -O -J -L https://github.com/pseudomuto/protoc-gen-doc/releases/download/v${PROTOC_VERSION}/protoc-gen-doc_${PROTOC_VERSION}_linux_amd64.tar.gz && \
-    tar -xzf protoc-gen-doc_1.5.1_linux_amd64.tar.gz && \
+    tar -xzf protoc-gen-doc_${PROTOC_VERSION}_linux_amd64.tar.gz && \
     chmod +x protoc-gen-doc && \
     mv protoc-gen-doc /usr/local/bin/protoc-gen-doc && \
-    rm protoc-gen-doc_1.5.1_linux_amd64.tar.gz
+    rm protoc-gen-doc_${PROTOC_VERSION}_linux_amd64.tar.gz
 
 ## Setup Buf
 RUN curl -sSL \
@@ -45,20 +45,9 @@ RUN curl -sSl -J -L "https://github.com/errata-ai/vale/releases/download/v${VALE
 
 WORKDIR /app
 
-FROM main AS planner
-RUN cargo install cargo-chef
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-RUN cargo chef cook --recipe-path recipe.json
-
 FROM main as local
-COPY --from=planner /usr/local/cargo/bin /usr/local/cargo/bin
-COPY --from=planner /usr/local/cargo/registry/index/ /usr/local/cargo/registry/index/
-COPY --from=planner /usr/local/cargo/registry/cache/ /usr/local/cargo/registry/cache/
 WORKDIR /app
 ENTRYPOINT ["make"]
 
 FROM main as builder
-COPY --from=planner /usr/local/cargo/bin /usr/local/cargo/bin
-COPY --from=planner /usr/local/cargo/registry/index/ /usr/local/cargo/registry/index/
-COPY --from=planner /usr/local/cargo/registry/cache/ /usr/local/cargo/registry/cache/
+WORKDIR /app


### PR DESCRIPTION
We're getting some 403 errors on build pipelines when this image is pushing to GHCR. Heres my thoughts that triggered this PR to fix it:

1) We have a 10GB limit on the cache for this project. We're at our about that constantly because this cache holds the cargo files, as well as the docker cache
2) Github is nice and cleans this up for us by when we used it last. But theres not much runway for things to exist. The image is ~1GB and I think the cargo dependencies are another ~300MB. And each change to Cargo.lock across branches would trigger both some new docker layers, as well as a new cache of the .cargo folders
3) This build is attempting to use a layer that it thinks is cached somehow, but it cant find the actual blob when it trys to copy from it. But it carries on
4) When GHA trys to push the image, its referencing a layer that doesnt actually exist in the cache, so it fails 


I am removing the `cargo-chef` step in the dockerfile. This will remove the cargo cache from the image itself, and hopefully remediate this issue now, and going forward. Because the image being built now is just the system dependencies, it will not be rebuilt nearly as often.