### PR TITLE
Add go_package to v0 api proto

### DIFF
--- a/api/v0/observe/observe.proto
+++ b/api/v0/observe/observe.proto
@@ -32,7 +32,7 @@ syntax = "proto3";
 
 package aurae.observe.v0;
 
-option go_package = "github.com/aurae-runtime/ae/client/pkg/api/observe/v0;observev0";
+option go_package = "github.com/aurae-runtime/ae/client/pkg/api/v0/observe;observev0";
 
 enum LogChannelType {
   LOG_CHANNEL_TYPE_UNSPECIFIED = 0;

--- a/api/v0/observe/observe.proto
+++ b/api/v0/observe/observe.proto
@@ -32,6 +32,8 @@ syntax = "proto3";
 
 package aurae.observe.v0;
 
+option go_package = "github.com/aurae-runtime/ae/client/pkg/api/observe/v0;observev0";
+
 enum LogChannelType {
   LOG_CHANNEL_TYPE_UNSPECIFIED = 0;
   LOG_CHANNEL_TYPE_STDOUT = 1;

--- a/api/v0/runtime/runtime.proto
+++ b/api/v0/runtime/runtime.proto
@@ -32,6 +32,8 @@ syntax = "proto3";
 
 package aurae.runtime.v0;
 
+option go_package = "github.com/aurae-runtime/ae/client/pkg/api/runtime/v0;runtimev0";
+
 /// Runtime
 /// ===
 ///

--- a/api/v0/runtime/runtime.proto
+++ b/api/v0/runtime/runtime.proto
@@ -32,7 +32,7 @@ syntax = "proto3";
 
 package aurae.runtime.v0;
 
-option go_package = "github.com/aurae-runtime/ae/client/pkg/api/runtime/v0;runtimev0";
+option go_package = "github.com/aurae-runtime/ae/client/pkg/api/v0/runtime;runtimev0";
 
 /// Runtime
 /// ===

--- a/api/v0/schedule/schedule.proto
+++ b/api/v0/schedule/schedule.proto
@@ -32,4 +32,6 @@ syntax = "proto3";
 
 package aurae.schedule.v0;
 
+option go_package = "github.com/aurae-runtime/ae/client/pkg/api/schedule/v0;schedulev0";
+
 // TODO Schedule subsystem

--- a/api/v0/schedule/schedule.proto
+++ b/api/v0/schedule/schedule.proto
@@ -32,6 +32,6 @@ syntax = "proto3";
 
 package aurae.schedule.v0;
 
-option go_package = "github.com/aurae-runtime/ae/client/pkg/api/schedule/v0;schedulev0";
+option go_package = "github.com/aurae-runtime/ae/client/pkg/api/v0/schedule;schedulev0";
 
 // TODO Schedule subsystem


### PR DESCRIPTION
In order to implement the gRPC go client, as per aurae-runtime/ae#13, it would be nice to add the `go_package` option to the proto files.
So that, the generated stubs are put in the correct go package.