### PR TITLE
Dependencies cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,6 @@ dependencies = [
  "futures",
  "ipnetwork",
  "iter_tools",
- "lazy_static",
  "libc",
  "libcontainer",
  "liboci-cli",
@@ -181,7 +180,6 @@ dependencies = [
  "rtnetlink",
  "simple_test_case",
  "simplelog",
- "sys-mount",
  "syslog",
  "thiserror",
  "tokio",
@@ -207,12 +205,7 @@ dependencies = [
  "auraescript_macros",
  "deno_ast",
  "deno_core",
- "serde",
  "tokio",
- "toml",
- "tonic",
- "tower",
- "x509-certificate",
 ]
 
 [[package]]
@@ -330,25 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.59.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,15 +387,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,17 +424,6 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1180,12 +1134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,12 +1423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lexical"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,16 +1556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if 1.0.0",
- "winapi",
-]
-
-[[package]]
 name = "liboci-cli"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,17 +1629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loopdev"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bfa0855b04611e38acaff718542e9e809cddfc16535d39f9d9c694ab19f7388"
-dependencies = [
- "bindgen",
- "errno",
- "libc",
-]
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,12 +1684,6 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1919,16 +1834,6 @@ dependencies = [
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2129,12 +2034,6 @@ dependencies = [
  "base64",
  "serde",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -2748,12 +2647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,17 +2703,6 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "smart-default"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "socket2"
@@ -3274,20 +3156,6 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
-
-[[package]]
-name = "sys-mount"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793d38aa916d55e979587ea7cf551106f5f091e548a91e89ee4f0698bc9cf289"
-dependencies = [
- "bitflags",
- "libc",
- "loopdev",
- "smart-default",
- "thiserror",
- "tracing",
-]
 
 [[package]]
 name = "syscalls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,9 @@ members = [
 anyhow = "1.0.66"
 aurae-client = { path = "./aurae-client" }
 aurae-proto = { path = "./aurae-proto" }
+fancy-regex = "0.10.0"
 lazy_static = "1.4.0"
+serde = "1.0"
 thiserror = "1.0.37"
 tokio = "1.22.0"
 tonic = "0.8.2"

--- a/aurae-client/Cargo.toml
+++ b/aurae-client/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.68"
+anyhow = { workspace = true }
 aurae-proto = { workspace = true }
 macros = { package = "aurae-client-macros", path = "macros" }
-serde = "1.0.147"
+serde = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 toml = "0.5.9"
 tonic = { workspace = true, features = ["tls"] }

--- a/aurae-proto/Cargo.toml
+++ b/aurae-proto/Cargo.toml
@@ -40,5 +40,5 @@ license = "Apache-2.0"
 [dependencies]
 pbjson = "0.5.1"
 prost = "0.11.2"
-serde = "1.0.147"
-tonic = "0.8.2"
+serde = { workspace = true }
+tonic = { workspace = true }

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -46,12 +46,11 @@ aurae-proto = { workspace = true }
 cgroups-rs = "0.2.11"
 clap = { version = "3.1.20", features = ["derive"] }
 clone3 = "0.2.3"
-fancy-regex = "0.10.0"
+fancy-regex = { workspace = true }
 futures = "0.3.23"
 ipnetwork = "0.20.0"
 iter_tools = "0.1.4"
-lazy_static = { workspace = true }
-libc = "0.2"
+libc = "0.2" # TODO: Nix comes with libc, can we rely on that?
 libcontainer = "0.0.4"
 liboci-cli = "0.0.4"
 log = "0.4.17"
@@ -62,7 +61,6 @@ ocipkg = "0.2.8"
 procfs = "0.14.2"
 rtnetlink = "0.11.0"
 simplelog = "0.12.0"
-sys-mount = "2.0.1"
 syslog = "6.0.1"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "fs", "rt-multi-thread", "sync", "signal", "process"] }

--- a/auraescript/Cargo.toml
+++ b/auraescript/Cargo.toml
@@ -40,15 +40,10 @@ name = "auraescript"
 path = "src/bin/main.rs"
 
 [dependencies]
-anyhow = {workspace = true}
+anyhow = { workspace = true }
 aurae-client = { workspace = true }
 aurae-proto = { workspace = true }
 deno_ast = { version = "0.21.0", features = ["transpiling"] }
 deno_core = "0.160.0"
 macros = { package = "auraescript_macros", path = "./macros" }
-serde = "1.0.147"
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
-toml = "0.5.9"
-tonic = { workspace = true, features = ["tls"] }
-tower = "0.4.13"
-x509-certificate = "0.15.0"

--- a/crates/validation/Cargo.toml
+++ b/crates/validation/Cargo.toml
@@ -13,12 +13,12 @@ tonic = ["dep:tonic"]
 url = ["dep:url"]
 
 [dependencies]
-fancy-regex = { version = "0.10.0", optional = true }
+fancy-regex = { workspace = true, optional = true }
 lazy_static = { workspace = true, optional = true }
 thiserror = { workspace = true }
 validator = "0.16.0"
 secrecy = { version = "0.8.0", optional = true }
-serde = { version = "1.0.147", optional = true }
+serde = { workspace = true, optional = true }
 serde_json = { version = "1.0.87", optional = true }
 tonic = { workspace = true, optional = true }
 url = { version = "2.3.1", optional = true }


### PR DESCRIPTION
Inspired by #260, some cleanup of dependencies after running cargo-machete.

auraed still shows the following packages as unused, but I think we may actually be using them:
- syslog
- tracing-log