### PR TITLE
Spawn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,18 @@ headers-check: ## Only check for problematic files.
 headers-write: ## Fix any problematic files blindly.
 	./hack/headers-write
 
+.PHONY: spawn
+spawn: ## Spawn the current auraed binary and start it in a container
+	./hack/spawn
+
+.PHONY: busybox
+busybox: ## Creat a "busybox" OCI bundle in target
+	./hack/oci-busybox
+
+.PHONY: alpine
+alpine: ## Creat an "alpine" OCI bundle in target
+	./hack/oci-alpine
+
 .PHONY: start
 start:
 	sudo -E $(HOME)/.cargo/bin/auraed
@@ -177,12 +189,10 @@ oci-image-build-raw: ## Plain Jane oci build
 container: ## Build the container defined in hack/container
 	./hack/container
 
-
-.PHONY: test-workflow
-test-workflow: ## Tests a github actions workflow locally using `act`
-	@act -W ./.github/workflows/$(file)
-
 .PHONY: check-deps
 check-deps: ## Check if there are any unused dependencies in Cargo.toml
 	cargo +nightly udeps --all-targets
 
+.PHONY: test-workflow
+test-workflow: ## Tests a github actions workflow locally using `act`
+	@act -W ./.github/workflows/$(file)

--- a/auraed/src/spawn/config.json
+++ b/auraed/src/spawn/config.json
@@ -1,0 +1,182 @@
+{
+  "ociVersion": "1.0.2-dev",
+  "root": {
+    "path": "rootfs",
+    "readonly": false
+  },
+  "mounts": [
+    {
+      "destination": "/proc",
+      "type": "proc",
+      "source": "proc"
+    },
+    {
+      "destination": "/dev",
+      "type": "tmpfs",
+      "source": "tmpfs",
+      "options": [
+        "nosuid",
+        "strictatime",
+        "mode=755",
+        "size=65536k"
+      ]
+    },
+    {
+      "destination": "/dev/pts",
+      "type": "devpts",
+      "source": "devpts",
+      "options": [
+        "nosuid",
+        "noexec",
+        "newinstance",
+        "ptmxmode=0666",
+        "mode=0620",
+        "gid=5"
+      ]
+    },
+    {
+      "destination": "/dev/shm",
+      "type": "tmpfs",
+      "source": "shm",
+      "options": [
+        "nosuid",
+        "noexec",
+        "nodev",
+        "mode=1777",
+        "size=65536k"
+      ]
+    },
+    {
+      "destination": "/dev/mqueue",
+      "type": "mqueue",
+      "source": "mqueue",
+      "options": [
+        "nosuid",
+        "noexec",
+        "nodev"
+      ]
+    },
+    {
+      "destination": "/sys",
+      "type": "sysfs",
+      "source": "sysfs",
+      "options": [
+        "nosuid",
+        "noexec",
+        "nodev",
+        "ro"
+      ]
+    },
+    {
+      "destination": "/sys/fs/cgroup",
+      "type": "cgroup",
+      "source": "cgroup",
+      "options": [
+        "nosuid",
+        "noexec",
+        "nodev",
+        "relatime",
+        "ro"
+      ]
+    }
+  ],
+  "process": {
+    "terminal": false,
+    "user": {
+      "uid": 0,
+      "gid": 0
+    },
+    "args": [
+      "init"
+    ],
+    "env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "TERM=xterm"
+    ],
+    "cwd": "/",
+    "capabilities": {
+      "bounding": [
+        "CAP_AUDIT_WRITE",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_KILL"
+      ],
+      "effective": [
+        "CAP_AUDIT_WRITE",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_KILL"
+      ],
+      "inheritable": [
+        "CAP_AUDIT_WRITE",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_KILL"
+      ],
+      "permitted": [
+        "CAP_AUDIT_WRITE",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_KILL"
+      ],
+      "ambient": [
+        "CAP_AUDIT_WRITE",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_KILL"
+      ]
+    },
+    "rlimits": [
+      {
+        "type": "RLIMIT_NOFILE",
+        "hard": 1024,
+        "soft": 1024
+      }
+    ],
+    "noNewPrivileges": true
+  },
+  "hostname": "aurae",
+  "annotations": {},
+  "linux": {
+    "resources": {
+      "devices": [
+        {
+          "allow": false,
+          "type": null,
+          "major": null,
+          "minor": null,
+          "access": "rwm"
+        }
+      ]
+    },
+    "namespaces": [
+      {
+        "type": "pid"
+      },
+      {
+        "type": "network"
+      },
+      {
+        "type": "ipc"
+      },
+      {
+        "type": "uts"
+      },
+      {
+        "type": "mount"
+      }
+    ],
+    "maskedPaths": [
+      "/proc/acpi",
+      "/proc/asound",
+      "/proc/kcore",
+      "/proc/keys",
+      "/proc/latency_stats",
+      "/proc/timer_list",
+      "/sys/firmware",
+      "/proc/scsi"
+    ],
+    "readonlyPaths": [
+      "/proc/bus",
+      "/proc/fs",
+      "/proc/irq",
+      "/proc/sys",
+      "/proc/sysrq-trigger"
+    ]
+  }
+}

--- a/auraed/src/spawn/mod.rs
+++ b/auraed/src/spawn/mod.rs
@@ -1,0 +1,105 @@
+/* -------------------------------------------------------------------------- *\
+ *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+use anyhow::Context;
+use std::fs;
+use std::fs::Permissions;
+use std::os::unix::prelude::PermissionsExt;
+use std::path::Path;
+
+const PROC_SELF_EXE: &str = "/proc/self/exe";
+const SPAWN_CONFIG: &[u8] = include_bytes!("config.json");
+
+pub fn spawn_auraed_oci_to(output: &str) -> Result<(), anyhow::Error> {
+    // Here we read /proc/self/exe which will be a symbolic link to our binary.
+    let auraed_path = fs::read_link(PROC_SELF_EXE)
+        .context("reading auraed sym link from procfs")?;
+    let binary_data = fs::read(auraed_path)
+        .context("reading auraed executable from procfs")?;
+    let oci_bundle_path = Path::new(output);
+
+    // Reset the output directory (if exists)
+    let _ =
+        fs::remove_dir_all(oci_bundle_path).context("remove output dir clean");
+    fs::create_dir_all(oci_bundle_path)
+        .context("create new output dir clean")?;
+
+    // Write our config.json
+    fs::write(oci_bundle_path.join(Path::new("config.json")), SPAWN_CONFIG)
+        .expect("writing default config.json for spawn image");
+
+    // .
+    // ├── config.json
+    // └── rootfs
+    //     └── bin
+    //         ├── auraed
+    //         └── init
+
+    // Create the initial file structure for the Auraed OCI container
+    //
+    // bin    etc    lib    media  opt    root   sbin   sys    usr
+    // dev    home   lib64  mnt    proc   run    srv    tmp    var
+    fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs")))?;
+    fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/bin")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/lib")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/media")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/opt")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/root")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/sbin")))?;
+    fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/sys")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/usr")))?;
+    fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/dev")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/home")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/lib64")))?;
+    fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/mnt")))?;
+    fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/proc")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/run")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/srv")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/tmp")))?;
+    //fs::create_dir_all(oci_bundle_path.join(Path::new("rootfs/var")))?;
+
+    // /bin/auraed
+    fs::write(
+        Path::new(&oci_bundle_path.join(Path::new("rootfs/bin/auraed"))),
+        binary_data,
+    )?;
+    fs::set_permissions(
+        Path::new(&oci_bundle_path.join(Path::new("rootfs/bin/auraed"))),
+        Permissions::from_mode(0o755),
+    )?;
+
+    fs::hard_link(
+        oci_bundle_path.join(Path::new("rootfs/bin/auraed")),
+        oci_bundle_path.join(Path::new("rootfs/bin/init")),
+    )
+    .expect("linking /bin/auraed to /bin/init");
+
+    Ok(())
+}

--- a/hack/oci-alpine
+++ b/hack/oci-alpine
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------- #
+#             Apache 2.0 License Copyright © 2022 The Aurae Authors            #
+#                                                                              #
+#                +--------------------------------------------+                #
+#                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |                #
+#                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |                #
+#                |  ███████║██║   ██║██████╔╝███████║█████╗   |                #
+#                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |                #
+#                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |                #
+#                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |                #
+#                +--------------------------------------------+                #
+#                                                                              #
+#                         Distributed Systems Runtime                          #
+#                                                                              #
+# ---------------------------------------------------------------------------- #
+#                                                                              #
+#   Licensed under the Apache License, Version 2.0 (the "License");            #
+#   you may not use this file except in compliance with the License.           #
+#   You may obtain a copy of the License at                                    #
+#                                                                              #
+#       http://www.apache.org/licenses/LICENSE-2.0                             #
+#                                                                              #
+#   Unless required by applicable law or agreed to in writing, software        #
+#   distributed under the License is distributed on an "AS IS" BASIS,          #
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+#   See the License for the specific language governing permissions and        #
+#   limitations under the License.                                             #
+#                                                                              #
+# ---------------------------------------------------------------------------- #
+
+rm -rf target/alpine
+mkdir -p target/alpine/rootfs
+sudo -E docker pull alpine
+sudo -E docker create --name alpine-aurae alpine
+sudo -E docker export alpine-aurae | tar -C target/alpine/rootfs -xf -
+sudo -E docker rm alpine-aurae
+cd target/alpine
+sudo -E runc spec

--- a/hack/oci-busybox
+++ b/hack/oci-busybox
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------- #
+#             Apache 2.0 License Copyright © 2022 The Aurae Authors            #
+#                                                                              #
+#                +--------------------------------------------+                #
+#                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |                #
+#                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |                #
+#                |  ███████║██║   ██║██████╔╝███████║█████╗   |                #
+#                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |                #
+#                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |                #
+#                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |                #
+#                +--------------------------------------------+                #
+#                                                                              #
+#                         Distributed Systems Runtime                          #
+#                                                                              #
+# ---------------------------------------------------------------------------- #
+#                                                                              #
+#   Licensed under the Apache License, Version 2.0 (the "License");            #
+#   you may not use this file except in compliance with the License.           #
+#   You may obtain a copy of the License at                                    #
+#                                                                              #
+#       http://www.apache.org/licenses/LICENSE-2.0                             #
+#                                                                              #
+#   Unless required by applicable law or agreed to in writing, software        #
+#   distributed under the License is distributed on an "AS IS" BASIS,          #
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+#   See the License for the specific language governing permissions and        #
+#   limitations under the License.                                             #
+#                                                                              #
+# ---------------------------------------------------------------------------- #
+
+rm -rf target/busybox
+mkdir -p target/busybox/rootfs
+sudo -E docker pull busybox
+sudo -E docker create --name busybox-aurae busybox
+sudo -E docker export busybox-aurae | tar -C target/busybox/rootfs -xf -
+sudo -E docker rm busybox-aurae
+cd target/busybox
+sudo -E runc spec

--- a/hack/spawn
+++ b/hack/spawn
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------- #
+#             Apache 2.0 License Copyright © 2022 The Aurae Authors            #
+#                                                                              #
+#                +--------------------------------------------+                #
+#                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |                #
+#                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |                #
+#                |  ███████║██║   ██║██████╔╝███████║█████╗   |                #
+#                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |                #
+#                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |                #
+#                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |                #
+#                +--------------------------------------------+                #
+#                                                                              #
+#                         Distributed Systems Runtime                          #
+#                                                                              #
+# ---------------------------------------------------------------------------- #
+#                                                                              #
+#   Licensed under the Apache License, Version 2.0 (the "License");            #
+#   you may not use this file except in compliance with the License.           #
+#   You may obtain a copy of the License at                                    #
+#                                                                              #
+#       http://www.apache.org/licenses/LICENSE-2.0                             #
+#                                                                              #
+#   Unless required by applicable law or agreed to in writing, software        #
+#   distributed under the License is distributed on an "AS IS" BASIS,          #
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+#   See the License for the specific language governing permissions and        #
+#   limitations under the License.                                             #
+#                                                                              #
+# ---------------------------------------------------------------------------- #
+
+CID="aurae-spawn-hack"
+BUNDLE="target/aurae-spawn"
+
+# [Spawn]
+# Assume we are running in the root top level directory
+# Assume we must create "aurae-spawn" as this is hard coded in auraed
+sudo -E auraed spawn --output ${BUNDLE}
+
+# [Run/Debug]
+echo "Delete:   ${CID}"
+sudo -E youki delete ${CID}
+
+echo "Create:   ${CID}"
+sudo -E youki create --bundle ${BUNDLE} ${CID}
+
+echo "Start :   ${CID}"
+sudo -E youki start ${CID}


### PR DESCRIPTION
This is why we need the musl builds. We want to be able to bring a clean binary to the spawned OCI image so we can create pods with ourself 🎉 

This PR introduces a new subcommand for `auraed

```bash 
auraed spawn --output /tmp # Create an OCI compliant container bundle in /tmp/aurae-spawn
chroot /tmp/aurae-spawn/rootfs
./sbin/init # Run auraed 😎 
```