### PR TITLE
Add aurae.io deploy back in

### DIFF
--- a/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
+++ b/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
@@ -55,14 +55,20 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - name: Install protoc-gen-doc in [ubuntu:latest]
+      - name: Install dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y libdbus-1-dev pkg-config libseccomp-dev
+          mkdir src
+          cd src
           wget https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.5.1/protoc-gen-doc_1.5.1_linux_amd64.tar.gz
           tar -xzf protoc-gen-doc_1.5.1_linux_amd64.tar.gz
           chmod +x protoc-gen-doc
           cp protoc-gen-doc /usr/local/bin/protoc-gen-doc
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          cd ../
+          rm -rf src
+          pip install mkdocs-material
       - name: Build Documentation [make docs]
         run: make docs
       - name: Deploy 'aurae.io' Website [mkdocs gh-deploy]

--- a/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
+++ b/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
@@ -49,20 +49,20 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-   container:
-     image: ghcr.io/${{ github.repository }}/aurae-builder:latest
-     credentials:
-       username:  ${{ github.actor }}
-       password:  ${{ secrets.GITHUB_TOKEN }}
-   steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-      - name: Install mkdocs-material [aurae-builder:latest]
-        run: |
-          pip install mkdocs-material
-      - name: Build Documentation [make docs]
-        run: make docs
-      # - name: Deploy 'aurae.io' Website [mkdocs gh-deploy]
-      #   run: mkdocs gh-deploy --force
+    container:
+      image: ghcr.io/${{ github.repository }}/aurae-builder:latest
+      credentials:
+        username:  ${{ github.actor }}
+        password:  ${{ secrets.GITHUB_TOKEN }}
+    steps:
+        - uses: actions/checkout@v3
+        - uses: actions/setup-python@v2
+          with:
+            python-version: 3.x
+        - name: Install mkdocs-material [aurae-builder:latest]
+          run: |
+            pip install mkdocs-material
+        - name: Build Documentation [make docs]
+          run: make docs
+        # - name: Deploy 'aurae.io' Website [mkdocs gh-deploy]
+        #   run: mkdocs gh-deploy --force

--- a/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
+++ b/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - name: Install dependencies
+      - name: Install protoc-gen-doc in [ubuntu:latest]
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
+++ b/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
@@ -43,8 +43,6 @@ name: "Deploy Website Documentation (091) [aurae:builder]"
 on:
  push:
    branches: main
- pull_request:
-   branches: main
 
 jobs:
   deploy:
@@ -66,5 +64,5 @@ jobs:
             pip install mkdocs-material
         - name: Build Documentation [make docs]
           run: make docs
-        # - name: Deploy 'aurae.io' Website [mkdocs gh-deploy]
-        #   run: mkdocs gh-deploy --force
+        - name: Deploy 'aurae.io' Website [mkdocs gh-deploy]
+          run: mkdocs gh-deploy --force

--- a/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
+++ b/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
@@ -61,6 +61,8 @@ jobs:
             python-version: 3.x
         - name: Install mkdocs-material [aurae-builder:latest]
           run: |
+            apt-get update 
+            apt-get install -y python3-pip
             pip install mkdocs-material
         - name: Build Documentation [make docs]
           run: make docs

--- a/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
+++ b/.github/workflows/091-deploy-website-documentation-ubuntu-make-docs.yml
@@ -39,37 +39,30 @@
 # When this build passes we should have confidence that our documentation is
 # updated on the website complete with best practices.
 #
-name: "Deploy Website Documentation (090) [ubuntu:latest]"
+name: "Deploy Website Documentation (091) [aurae:builder]"
 on:
-  push:
-    branches:
-      - main
+ push:
+   branches: main
+ pull_request:
+   branches: main
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    steps:
+   container:
+     image: ghcr.io/${{ github.repository }}/aurae-builder:latest
+     credentials:
+       username:  ${{ github.actor }}
+       password:  ${{ secrets.GITHUB_TOKEN }}
+   steps:
       - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ github.token }}
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - name: Install protoc-gen-doc in [ubuntu:latest]
+      - name: Install mkdocs-material [aurae-builder:latest]
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
-          sudo apt-get install -y libdbus-1-dev pkg-config libseccomp-dev
-          mkdir src
-          cd src
-          wget https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.5.1/protoc-gen-doc_1.5.1_linux_amd64.tar.gz
-          tar -xzf protoc-gen-doc_1.5.1_linux_amd64.tar.gz
-          chmod +x protoc-gen-doc
-          cp protoc-gen-doc /usr/local/bin/protoc-gen-doc
-          cd ../
-          rm -rf src
           pip install mkdocs-material
       - name: Build Documentation [make docs]
         run: make docs
-      - name: Deploy 'aurae.io' Website [mkdocs gh-deploy]
-        run: mkdocs gh-deploy --force
+      # - name: Deploy 'aurae.io' Website [mkdocs gh-deploy]
+      #   run: mkdocs gh-deploy --force


### PR DESCRIPTION
I think we lost this bit:
https://github.com/aurae-runtime/aurae/compare/Add-aurae.io-deploy-back-in?expand=1#diff-bd486993fba0fc0263741470fd4f9f35be18e60deee39f2225dbf07fbf41ab45R71