### PR TITLE
Connect to nested cells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "anyhow",
  "aurae-client",
  "aurae-proto",
+ "backoff",
  "cgroups-rs",
  "clap",
  "clone3",
@@ -268,6 +269,20 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
 ]
 
 [[package]]
@@ -1165,6 +1180,15 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -43,6 +43,7 @@ path = "src/bin/main.rs"
 anyhow = { workspace = true }
 aurae-client = { workspace = true }
 aurae-proto = { workspace = true }
+backoff = { version = "0.4.0", features = ["tokio"] }
 cgroups-rs = "0.3.0"
 clap = { version = "3.1.20", features = ["derive"] }
 clone3 = "0.2.3"

--- a/auraed/src/runtime/cell_service/cells/cell_name_path.rs
+++ b/auraed/src/runtime/cell_service/cells/cell_name_path.rs
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *\
- *             Apache 2.0 License Copyright © 2022 The Aurae Authors          *
+ *             Apache 2.0 License Copyright © 2022-2023 The Aurae Authors          *
  *                                                                            *
  *                +--------------------------------------------+              *
  *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
@@ -28,37 +28,83 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-use crate::runtime::cell_service::executables::auraed::IsolationControls;
-use cell::Cell;
-pub use cell_name::CellName;
-pub use cell_name_path::CellNamePath;
-pub use cells::Cells;
-use cgroups::CgroupSpec;
-pub use error::{CellsError, Result};
+use crate::runtime::cell_service::cells::CellName;
+use iter_tools::Itertools;
+use std::collections::VecDeque;
+use validation::{ValidatedField, ValidationError};
 
-mod cell;
-mod cell_name;
-pub mod cell_name_path;
-#[allow(clippy::module_inception)]
-mod cells;
-pub mod cgroups;
-mod error;
+pub const SEPARATOR: &str = "/";
 
 #[derive(Debug, Clone)]
-pub struct CellSpec {
-    pub cgroup_spec: CgroupSpec,
-    pub iso_ctl: IsolationControls,
+pub enum CellNamePath {
+    Empty,
+    CellName(CellName),
+    Path(VecDeque<CellName>),
 }
 
-impl CellSpec {
-    #[cfg(test)]
-    pub(crate) fn new_for_tests() -> Self {
-        Self {
-            cgroup_spec: CgroupSpec { cpu: None, cpuset: None },
-            iso_ctl: IsolationControls {
-                isolate_network: false,
-                isolate_process: false,
-            },
+impl CellNamePath {
+    /// Returns [None] if current variant is [CellNamePath::Empty]
+    pub fn into_child(self) -> Option<(CellName, Self)> {
+        match self {
+            CellNamePath::Empty => None,
+            CellNamePath::CellName(cell_name) => Some((cell_name, Self::Empty)),
+            CellNamePath::Path(mut parts) => {
+                let cell_name = parts.pop_front().expect("parent CellName");
+                Some(match parts.len() {
+                    0 => unreachable!(
+                        "Path variant should only be constructed when length is > 1"
+                    ),
+                    1 => (cell_name, Self::CellName(parts.pop_front().expect("length is 1"))),
+                    _ => (cell_name, Self::Path(parts)),
+                })
+            }
+        }
+    }
+
+    pub fn into_string(self) -> String {
+        match self {
+            CellNamePath::Empty => "".into(),
+            CellNamePath::CellName(cell_name) => cell_name.into_inner(),
+            CellNamePath::Path(parts) => parts.into_iter().join(SEPARATOR),
+        }
+    }
+}
+
+impl ValidatedField<String> for CellNamePath {
+    fn validate(
+        input: Option<String>,
+        field_name: &str,
+        parent_name: Option<&str>,
+    ) -> Result<Self, ValidationError> {
+        let input = validation::required(input, field_name, parent_name)?;
+
+        if input.is_empty() {
+            return Ok(Self::Empty);
+        }
+
+        let parts: Vec<_> = input.split(SEPARATOR).collect();
+
+        if parts.len() == 1 {
+            let cell_name = CellName::validate_for_creation(
+                Some(input),
+                field_name,
+                parent_name,
+            )?;
+
+            Ok(Self::CellName(cell_name))
+        } else {
+            let parts = parts
+                .into_iter()
+                .flat_map(|cell_name| {
+                    CellName::validate_for_creation(
+                        Some(cell_name.into()),
+                        field_name,
+                        parent_name,
+                    )
+                })
+                .collect();
+
+            Ok(Self::Path(parts))
         }
     }
 }

--- a/auraed/src/runtime/cell_service/validation.rs
+++ b/auraed/src/runtime/cell_service/validation.rs
@@ -4,7 +4,7 @@ use super::cells::{
         cpuset::{Cpus, Mems},
         CgroupSpec, Limit, Weight,
     },
-    CellName,
+    CellNamePath,
 };
 use super::executables::{auraed::IsolationControls, ExecutableName};
 use aurae_proto::runtime::{
@@ -12,7 +12,7 @@ use aurae_proto::runtime::{
     CellServiceStartRequest, CellServiceStopRequest, CpuController,
     CpusetController, Executable,
 };
-use std::{collections::VecDeque, ffi::OsString};
+use std::ffi::OsString;
 use tokio::process::Command;
 use validation::{ValidatedField, ValidatedType, ValidationError};
 use validation_macros::ValidatedType;
@@ -48,8 +48,7 @@ impl CellServiceAllocateRequestTypeValidator
 #[derive(ValidatedType, Debug, Clone)]
 pub struct ValidatedCell {
     #[field_type(String)]
-    #[validate(create)]
-    pub name: CellName,
+    pub name: CellNamePath,
 
     #[field_type(Option<CpuController>)]
     pub cpu: Option<ValidatedCpuController>,
@@ -65,6 +64,22 @@ pub struct ValidatedCell {
 }
 
 impl CellTypeValidator for CellValidator {
+    fn validate_name(
+        name: String,
+        field_name: &str,
+        parent_name: Option<&str>,
+    ) -> Result<CellNamePath, ValidationError> {
+        let name = CellNamePath::validate(Some(name), field_name, parent_name)?;
+
+        if matches!(name, CellNamePath::Empty) {
+            return Err(ValidationError::Required {
+                field: validation::field_name(field_name, parent_name),
+            });
+        }
+
+        Ok(name)
+    }
+
     fn validate_cpu(
         cpu: Option<CpuController>,
         field_name: &str,
@@ -159,43 +174,38 @@ impl From<ValidatedCpusetController> for cgroups::cpuset::CpusetController {
 #[derive(Debug, ValidatedType)]
 pub struct ValidatedCellServiceFreeRequest {
     #[field_type(String)]
-    #[validate]
-    pub cell_name: CellName,
+    pub cell_name: CellNamePath,
 }
 
-impl CellServiceFreeRequestTypeValidator for CellServiceFreeRequestValidator {}
+impl CellServiceFreeRequestTypeValidator for CellServiceFreeRequestValidator {
+    fn validate_cell_name(
+        cell_name: String,
+        field_name: &str,
+        parent_name: Option<&str>,
+    ) -> Result<CellNamePath, ValidationError> {
+        let cell_name =
+            CellNamePath::validate(Some(cell_name), field_name, parent_name)?;
+
+        if matches!(cell_name, CellNamePath::Empty) {
+            return Err(ValidationError::Required {
+                field: validation::field_name(field_name, parent_name),
+            });
+        }
+
+        Ok(cell_name)
+    }
+}
 
 #[derive(Debug, ValidatedType)]
 pub struct ValidatedCellServiceStartRequest {
     #[field_type(String)]
-    pub cell_name: VecDeque<CellName>,
+    #[validate]
+    pub cell_name: CellNamePath,
     #[field_type(Option<Executable>)]
     pub executable: ValidatedExecutable,
 }
 
 impl CellServiceStartRequestTypeValidator for CellServiceStartRequestValidator {
-    fn validate_cell_name(
-        cell_name: String,
-        field_name: &str,
-        parent_name: Option<&str>,
-    ) -> Result<VecDeque<CellName>, ValidationError> {
-        let cell_name =
-            validation::required(Some(cell_name), field_name, parent_name)?;
-
-        let cell_name = cell_name
-            .split('/')
-            .flat_map(|cell_name| {
-                CellName::validate_for_creation(
-                    Some(cell_name.into()),
-                    field_name,
-                    parent_name,
-                )
-            })
-            .collect();
-
-        Ok(cell_name)
-    }
-
     fn validate_executable(
         executable: Option<Executable>,
         field_name: &str,
@@ -213,36 +223,14 @@ impl CellServiceStartRequestTypeValidator for CellServiceStartRequestValidator {
 #[derive(Debug, ValidatedType)]
 pub struct ValidatedCellServiceStopRequest {
     #[field_type(String)]
-    pub cell_name: VecDeque<CellName>,
+    #[validate]
+    pub cell_name: CellNamePath,
     #[field_type(String)]
     #[validate]
     pub executable_name: ExecutableName,
 }
 
-impl CellServiceStopRequestTypeValidator for CellServiceStopRequestValidator {
-    fn validate_cell_name(
-        cell_name: String,
-        field_name: &str,
-        parent_name: Option<&str>,
-    ) -> Result<VecDeque<CellName>, ValidationError> {
-        // TODO: refactor to a CellNamePath maybe
-        let cell_name =
-            validation::required(Some(cell_name), field_name, parent_name)?;
-
-        let cell_name = cell_name
-            .split('/')
-            .flat_map(|cell_name| {
-                CellName::validate_for_creation(
-                    Some(cell_name.into()),
-                    field_name,
-                    parent_name,
-                )
-            })
-            .collect();
-
-        Ok(cell_name)
-    }
-}
+impl CellServiceStopRequestTypeValidator for CellServiceStopRequestValidator {}
 
 #[derive(ValidatedType, Debug)]
 pub struct ValidatedExecutable {


### PR DESCRIPTION
`CellService` has been updated to properly proxy requests to nested cells. Nested cells can be addressed by the client by using a path to the cell, with '/' as the separator (e.g., `cellName: "grandparent/parent/child-cell"`).

The `CellService` will now retry connecting to the nested auraed. I picked values for the backoff, but I don't know if they match what we want. 

In future PRs we may want to make the backoff values configurable (with defaults).