### PR TITLE
Generate auraescript from protos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,10 +213,13 @@ dependencies = [
 
 [[package]]
 name = "auraescript_macros"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "heck",
  "proc-macro2",
+ "proto-reader",
+ "protobuf",
+ "protobuf-parse",
  "quote",
  "syn",
 ]
@@ -1956,6 +1959,14 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "proto-reader"
+version = "0.0.0"
+dependencies = [
+ "protobuf-parse",
  "syn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "0.0.0"
 dependencies = [
  "heck",
  "proc-macro2",
- "protobuf-parse",
+ "proto-reader",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,13 @@ anyhow = "1.0.66"
 aurae-client = { path = "./aurae-client" }
 aurae-proto = { path = "./aurae-proto" }
 fancy-regex = "0.10.0"
+heck = "0.4.0"
 lazy_static = "1.4.0"
+proc-macro2 = "1.0"
+protobuf-parse = "=3.2.0" # This crate makes no promises of stabilty, so we pin to the exact version
+quote = "1.0"
 serde = "1.0"
+syn = { version = "1.0", features = ["full"] } # used in macros, so full doesn't affect binary size
 thiserror = "1.0.37"
 tokio = "1.22.0"
 tonic = "0.8.2"

--- a/aurae-client/macros/Cargo.toml
+++ b/aurae-client/macros/Cargo.toml
@@ -10,6 +10,6 @@ proc-macro = true
 [dependencies]
 heck = { workspace = true }
 proc-macro2 = { workspace = true }
-protobuf-parse = { workspace = true }
+proto-reader = { path = "../../crates/proto-reader" } # using workspace isn't working
 quote = { workspace = true }
 syn = { workspace = true }

--- a/aurae-client/macros/Cargo.toml
+++ b/aurae-client/macros/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 proc-macro = true
 
 [dependencies]
-heck = "0.4.0"
-proc-macro2 = "1.0.44"
-protobuf-parse = "=3.2.0" # This crate makes no promises of stabilty, so we pin to the exact version
-quote = "1.0.21"
-syn = { version = "1.0.101", features = ['full'] }
+heck = { workspace = true }
+proc-macro2 = { workspace = true }
+protobuf-parse = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/aurae-client/macros/src/service.rs
+++ b/aurae-client/macros/src/service.rs
@@ -2,8 +2,6 @@ use heck::ToSnakeCase;
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
 use quote::quote;
-use std::path::PathBuf;
-use std::str::FromStr;
 use syn::parse::{Parse, ParseStream};
 use syn::{parse_macro_input, Lit, Path, Token};
 
@@ -31,56 +29,13 @@ pub(crate) fn service(input: TokenStream) -> TokenStream {
     let ServiceInput { file_path, module, service_name } =
         parse_macro_input!(input as ServiceInput);
 
-    let crate_root = match std::env::var("CARGO_MANIFEST_DIR") {
-        Ok(dir) => PathBuf::from(dir),
-        _ => panic!("env variable 'CARGO_MANIFEST_DIR' was not set. Failed to find crate root"),
-    };
+    let (_, proto) = proto_reader::parse(&file_path);
 
-    let parsed_file_path = match &file_path {
-        Lit::Str(file_path) => {
-            let file_path = file_path.value();
-            let file_path = file_path.trim_matches('"');
-
-            let file_path = crate_root.join(file_path);
-
-            file_path.canonicalize().unwrap_or_else(|e| {
-                panic!(
-                    "failed to determine absolute path for {file_path:?}: {e}"
-                )
-            })
-        }
-        _ => panic!(
-            "expected literal string with path to proto file as first argument"
-        ),
-    };
-
-    let mut api_dir = parsed_file_path.clone();
-    let api_dir = loop {
-        match api_dir.parent() {
-            Some(parent) => {
-                if parent.is_dir() && parent.ends_with("api") {
-                    break parent;
-                } else {
-                    api_dir = parent.to_path_buf();
-                }
-            }
-            _ => panic!("proto file not in api directory"),
-        }
-    };
-
-    let content = protobuf_parse::Parser::new()
-        .protoc()
-        .protoc_extra_args(["--experimental_allow_proto3_optional"])
-        .include(api_dir)
-        .input(&parsed_file_path)
-        .parse_and_typecheck()
-        .expect("failed to parse proto file");
-
-    let service = content
+    let service = proto
         .file_descriptors
         .iter()
         .flat_map(|x| &x.service)
-        .find(|x| matches!(&x.name, Some(y) if service_name == y))
+        .find(|x| matches!(x.name(), n if service_name == n))
         .expect("failed to find service");
 
     let client_namespace = Ident::new(
@@ -96,19 +51,14 @@ pub(crate) fn service(input: TokenStream) -> TokenStream {
         Ident::new(&fn_name.to_string().to_snake_case(), file_path.span())
     });
 
-    let rpc_signatures: Vec<_> = service.method.iter().zip(fn_name_idents.clone()).map(
-        |(m, name)| {
-            let input_type = proc_macro2::TokenStream::from_str(m.input_type
-                .as_ref()
-                .map(|x| x.split('.').last().expect("input type"))
-                .expect("rpc function is missing input type")
-            ).expect("rpc input type is not valid");
-
-            let output_type = proc_macro2::TokenStream::from_str(m.output_type
-                .as_ref()
-                .map(|x| x.split('.').last().expect("output type"))
-                .expect("rpc function is missing output type")
-            ).expect("rpc output type is not valid");
+    let rpc_signatures: Vec<_> = service.method
+        .iter()
+        .zip(fn_name_idents.clone())
+        .map(|(m, name)| {
+            let input_type = proto_reader::helpers::to_unqualified_type(m.input_type());
+            let input_type = Ident::new(input_type, file_path.span());
+            let output_type = proto_reader::helpers::to_unqualified_type(m.output_type());
+            let output_type = Ident::new(output_type, file_path.span());
 
             match (m.client_streaming.unwrap_or(false), m.server_streaming.unwrap_or(false)) {
                 (true, true) => {
@@ -122,7 +72,12 @@ pub(crate) fn service(input: TokenStream) -> TokenStream {
                         async fn #name(
                             &self,
                             req: ::aurae_proto::#module::#input_type
-                        ) -> Result<::tonic::Response<::tonic::Streaming<::aurae_proto::#module::#output_type >>, ::tonic::Status>
+                        ) -> Result<
+                            ::tonic::Response<
+                                ::tonic::Streaming<::aurae_proto::#module::#output_type>
+                            >,
+                            ::tonic::Status
+                        >
                     }
                 }
                 _ => {
@@ -130,7 +85,10 @@ pub(crate) fn service(input: TokenStream) -> TokenStream {
                         async fn #name(
                             &self,
                             req: ::aurae_proto::#module::#input_type
-                        ) -> Result<::tonic::Response<::aurae_proto::#module::#output_type>, ::tonic::Status>
+                        ) -> Result<
+                            ::tonic::Response<::aurae_proto::#module::#output_type>,
+                            ::tonic::Status
+                        >
                     }
                 }
             }

--- a/auraescript/macros/Cargo.toml
+++ b/auraescript/macros/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
 name = "auraescript_macros"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 proc-macro = true
 
 [dependencies]
-heck = "0.4.0"
-proc-macro2 = "1.0.44"
-quote = "1.0.21"
-syn = { version = "1.0.101", features = ['full'] }
+heck = { workspace = true }
+proc-macro2 = { workspace = true }
+protobuf = "3.2.0"
+protobuf-parse = { workspace = true }
+proto-reader = { path = "../../crates/proto-reader" } # using workspace isn't working
+quote = { workspace = true }
+syn = { workspace = true }

--- a/auraescript/macros/src/lib.rs
+++ b/auraescript/macros/src/lib.rs
@@ -55,16 +55,6 @@ use proc_macro::TokenStream;
 
 mod ops;
 
-// TODO (future-highway): Due to needing to ignore certain tests in CI, we can't format
-//    the code in the docs as cargo test will try to test it. Workaround or add the needed
-//    deps to this crate to make it pass.
-/// # Example:
-/// macros::ops_generator!(
-///     module_name,
-///     ServiceName,
-///     snake_case_rpc_name(RequestMessageName) -> ResponseMessageName,
-///     other(OtherRequest) -> OtherResponse
-/// );
 #[proc_macro]
 pub fn ops_generator(input: TokenStream) -> TokenStream {
     ops::ops_generator(input)

--- a/auraescript/macros/src/ops.rs
+++ b/auraescript/macros/src/ops.rs
@@ -38,7 +38,7 @@ pub(crate) fn ops_generator(input: TokenStream) -> TokenStream {
 
     let file_path_span = file_path.span();
 
-    let (file_path, proto) = proto_reader::parse(file_path);
+    let (file_path, proto) = proto_reader::parse(&file_path);
 
     typescript_generator(&file_path, &module, &proto, &service_names);
 

--- a/auraescript/src/cri.rs
+++ b/auraescript/src/cri.rs
@@ -30,7 +30,7 @@
 
 // TODO: macro doesn't support streaming. Does deno?
 macros::ops_generator!(
-    kubernetes::cri,
+    kubernetes::cri("kubernetes/cri/v1/release-1.26.ts"),
     {
         RuntimeService,
         version(VersionRequest) -> VersionResponse,

--- a/auraescript/src/discovery.rs
+++ b/auraescript/src/discovery.rs
@@ -29,9 +29,7 @@
 \* -------------------------------------------------------------------------- */
 
 macros::ops_generator!(
-    discovery("v0/discovery/discovery.ts"),
-    {
-        DiscoveryService,
-        discover(DiscoverRequest) -> DiscoverResponse,
-    },
+    "../api/v0/discovery/discovery.proto",
+    discovery,
+    DiscoveryService,
 );

--- a/auraescript/src/discovery.rs
+++ b/auraescript/src/discovery.rs
@@ -29,7 +29,7 @@
 \* -------------------------------------------------------------------------- */
 
 macros::ops_generator!(
-    discovery,
+    discovery("v0/discovery/discovery.ts"),
     {
         DiscoveryService,
         discover(DiscoverRequest) -> DiscoverResponse,

--- a/auraescript/src/health.rs
+++ b/auraescript/src/health.rs
@@ -30,7 +30,7 @@
 
 // TODO: macro doesn't support streaming. Does deno?
 macros::ops_generator!(
-    grpc::health,
+    grpc::health("grpc/health/v1/health.ts"),
     {
         Health,
         check(HealthCheckRequest) -> HealthCheckResponse

--- a/auraescript/src/health.rs
+++ b/auraescript/src/health.rs
@@ -30,10 +30,7 @@
 
 // TODO: macro doesn't support streaming. Does deno?
 macros::ops_generator!(
-    grpc::health("grpc/health/v1/health.ts"),
-    {
-        Health,
-        check(HealthCheckRequest) -> HealthCheckResponse
-        // watch(HealthCheckRequest) -> [HealthCheckResponse]
-    }
+    "../api/grpc/health/v1/health.proto",
+    grpc::health,
+    Health,
 );

--- a/auraescript/src/runtime.rs
+++ b/auraescript/src/runtime.rs
@@ -29,7 +29,7 @@
 \* -------------------------------------------------------------------------- */
 
 macros::ops_generator!(
-    runtime,
+    runtime("v0/runtime/runtime.ts"),
     {
         CellService,
         allocate(CellServiceAllocateRequest) -> CellServiceAllocateResponse,

--- a/auraescript/src/runtime.rs
+++ b/auraescript/src/runtime.rs
@@ -29,19 +29,8 @@
 \* -------------------------------------------------------------------------- */
 
 macros::ops_generator!(
-    runtime("v0/runtime/runtime.ts"),
-    {
-        CellService,
-        allocate(CellServiceAllocateRequest) -> CellServiceAllocateResponse,
-        free(CellServiceFreeRequest) -> CellServiceFreeResponse,
-        start(CellServiceStartRequest) -> CellServiceStartResponse,
-        stop(CellServiceStopRequest) -> CellServiceStopResponse,
-    },
-    {
-        PodService,
-        allocate(PodServiceAllocateRequest) -> PodServiceAllocateResponse,
-        free(PodServiceFreeRequest) -> PodServiceFreeResponse,
-        start(PodServiceStartRequest) -> PodServiceStartResponse,
-        stop(PodServiceStopRequest) -> PodServiceStopResponse,
-    },
+    "../api/v0/runtime/runtime.proto",
+    runtime,
+    CellService,
+    PodService,
 );

--- a/crates/proto-reader/Cargo.toml
+++ b/crates/proto-reader/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "proto-reader"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+protobuf-parse = { workspace = true }
+syn = { workspace = true }

--- a/crates/proto-reader/src/helpers.rs
+++ b/crates/proto-reader/src/helpers.rs
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *\
- *             Apache 2.0 License Copyright © 2022-2023 The Aurae Authors          *
+ *          Apache 2.0 License Copyright © 2022-2023 The Aurae Authors        *
  *                                                                            *
  *                +--------------------------------------------+              *
  *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
@@ -28,10 +28,6 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-// TODO: macro doesn't support streaming. Does deno?
-macros::ops_generator!(
-    "../api/kubernetes/cri/v1/release-1.26.proto",
-    kubernetes::cri,
-    RuntimeService,
-    ImageService,
-);
+pub fn to_unqualified_type(t: &str) -> &str {
+    t.split('.').last().expect("to_unqualified_type")
+}

--- a/crates/proto-reader/src/lib.rs
+++ b/crates/proto-reader/src/lib.rs
@@ -35,13 +35,13 @@ use std::path::PathBuf;
 use syn::Lit;
 
 /// Returns a tuple of a [PathBuf] to the proto file and the [ParsedAndTypechecked] output.
-pub fn parse(file_path: Lit) -> (PathBuf, ParsedAndTypechecked) {
+pub fn parse(file_path: &Lit) -> (PathBuf, ParsedAndTypechecked) {
     let crate_root = match std::env::var("CARGO_MANIFEST_DIR") {
         Ok(dir) => PathBuf::from(dir),
         _ => panic!("env variable 'CARGO_MANIFEST_DIR' was not set. Failed to find crate root"),
     };
 
-    let parsed_file_path = match &file_path {
+    let parsed_file_path = match file_path {
         Lit::Str(file_path) => {
             let file_path = file_path.value();
             let file_path = file_path.trim_matches('"');

--- a/crates/proto-reader/src/lib.rs
+++ b/crates/proto-reader/src/lib.rs
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *\
- *             Apache 2.0 License Copyright © 2022-2023 The Aurae Authors          *
+ *        Apache 2.0 License Copyright © 2022-2023 The Aurae Authors          *
  *                                                                            *
  *                +--------------------------------------------+              *
  *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
@@ -28,10 +28,56 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-// TODO: macro doesn't support streaming. Does deno?
-macros::ops_generator!(
-    "../api/kubernetes/cri/v1/release-1.26.proto",
-    kubernetes::cri,
-    RuntimeService,
-    ImageService,
-);
+pub mod helpers;
+
+use protobuf_parse::{ParsedAndTypechecked, Parser};
+use std::path::PathBuf;
+use syn::Lit;
+
+/// Returns a tuple of a [PathBuf] to the proto file and the [ParsedAndTypechecked] output.
+pub fn parse(file_path: Lit) -> (PathBuf, ParsedAndTypechecked) {
+    let crate_root = match std::env::var("CARGO_MANIFEST_DIR") {
+        Ok(dir) => PathBuf::from(dir),
+        _ => panic!("env variable 'CARGO_MANIFEST_DIR' was not set. Failed to find crate root"),
+    };
+
+    let parsed_file_path = match &file_path {
+        Lit::Str(file_path) => {
+            let file_path = file_path.value();
+            let file_path = file_path.trim_matches('"');
+
+            let file_path = crate_root.join(file_path);
+
+            file_path.canonicalize().unwrap_or_else(|e| {
+                panic!(
+                    "failed to determine absolute path for {file_path:?}: {e}"
+                )
+            })
+        }
+        _ => panic!("expected literal string with path to proto file in the api directory"),
+    };
+
+    let mut api_dir = parsed_file_path.clone();
+    let api_dir = loop {
+        match api_dir.parent() {
+            Some(parent) => {
+                if parent.is_dir() && parent.ends_with("api") {
+                    break parent;
+                } else {
+                    api_dir = parent.to_path_buf();
+                }
+            }
+            _ => panic!("proto file not in api directory"),
+        }
+    };
+
+    let proto = Parser::new()
+        .protoc()
+        .protoc_extra_args(["--experimental_allow_proto3_optional"])
+        .include(api_dir)
+        .input(&parsed_file_path)
+        .parse_and_typecheck()
+        .expect("failed to parse proto file");
+
+    (parsed_file_path, proto)
+}

--- a/crates/validation/macros/Cargo.toml
+++ b/crates/validation/macros/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 proc-macro = true
 
 [dependencies]
-heck = "0.4.0"
-proc-macro2 = "1.0.36"
-quote = "1.0.15"
-syn = { version = "1.0.86", features = ['full'] }
+heck = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }


### PR DESCRIPTION
The auraescript macro was relying on convention to locate the generated typescript files. As we brought in 3rd party protos, they do not match the project's conventions and thus needed carve outs.

This PR makes the path explicit in the macro instead of relying on conventions.