### PR TITLE
Allow multiple cell nesting 

### DIFF
--- a/aer/src/runtime/cell_service.rs
+++ b/aer/src/runtime/cell_service.rs
@@ -129,7 +129,7 @@ impl CellServiceCommands {
                 executable_description,
             } => {
                 let req = CellServiceStartRequest {
-                    cell_name,
+                    cell_name: Some(cell_name),
                     executable: Some(Executable {
                         name: executable_name,
                         command: executable_command,
@@ -141,7 +141,10 @@ impl CellServiceCommands {
                 let _ = execute!(CellServiceClient::start, req);
             }
             CellServiceCommands::Stop { cell_name, executable_name } => {
-                let req = CellServiceStopRequest { cell_name, executable_name };
+                let req = CellServiceStopRequest {
+                    cell_name: Some(cell_name),
+                    executable_name,
+                };
                 let _ = execute!(CellServiceClient::stop, req);
             }
         }

--- a/api/v0/runtime/runtime.proto
+++ b/api/v0/runtime/runtime.proto
@@ -259,7 +259,7 @@ message CellServiceFreeResponse {}
 /// Here you can define shell commands, and meta information about the command.
 /// An executable is started synchronously.
 message CellServiceStartRequest {
-  string cell_name = 1;
+  optional string cell_name = 1;
   Executable executable = 2;
 }
 
@@ -278,7 +278,7 @@ message CellServiceStartResponse {
 
 /// Request to stop an executable at runtime.
 message CellServiceStopRequest {
-  string cell_name = 1;
+  optional string cell_name = 1;
   string executable_name = 2;
 }
 

--- a/auraed/src/graceful_shutdown.rs
+++ b/auraed/src/graceful_shutdown.rs
@@ -102,6 +102,12 @@ impl GracefulShutdown {
                 "Attempt to free all cells on terminate resulted in error: {e}"
             )
         }
+
+        if let Err(e) = self.cell_service.stop_all().await {
+            error!(
+                "Attempt to stop all executables on terminate resulted in error: {e}"
+            )
+        }
     }
 }
 

--- a/auraed/src/runtime/cell_service/cell_service.rs
+++ b/auraed/src/runtime/cell_service/cell_service.rs
@@ -230,6 +230,13 @@ impl CellService {
     ) -> std::result::Result<Response<CellServiceStopResponse>, Status> {
         do_in_cell!(self, cell_name, stop, request)
     }
+
+    #[tracing::instrument(skip(self))]
+    pub(crate) async fn stop_all(&self) -> Result<()> {
+        let mut executables = self.executables.lock().await;
+        executables.broadcast_stop().await;
+        Ok(())
+    }
 }
 
 /// ### Mapping cgroup options to the Cell API

--- a/auraed/src/runtime/cell_service/cell_service.rs
+++ b/auraed/src/runtime/cell_service/cell_service.rs
@@ -29,7 +29,7 @@
 \* -------------------------------------------------------------------------- */
 
 use super::{
-    cells::{cell_name_path, CellName, CellNamePath, Cells},
+    cells::{CellName, Cells, CellsCache},
     error::CellsServiceError,
     executables::Executables,
     validation::{
@@ -125,32 +125,17 @@ impl CellService {
     ) -> Result<CellServiceAllocateResponse> {
         // Initialize the cell
         let ValidatedCellServiceAllocateRequest { cell } = request;
-        let (cell_name, empty) =
-            cell.name.clone().into_child().expect("not empty");
 
-        // There should have been a single cell name in the path.
-        // Otherwise, we should have called allocate_in_cell
-        assert!(matches!(empty, CellNamePath::Empty));
-
+        let cell_name = cell.name.clone();
         let cell_spec = cell.into();
 
         let mut cells = self.cells.lock().await;
         let cell = cells.allocate(cell_name, cell_spec)?;
 
         Ok(CellServiceAllocateResponse {
-            cell_name: cell.name().clone().into_inner(),
+            cell_name: cell.name().clone().to_string(),
             cgroup_v2: cell.v2().expect("allocated cell returns `Some`"),
         })
-    }
-
-    #[tracing::instrument(skip(self))]
-    async fn allocate_in_cell(
-        &self,
-        cell_name: &CellName,
-        request: CellServiceAllocateRequest,
-    ) -> std::result::Result<Response<CellServiceAllocateResponse>, Status>
-    {
-        do_in_cell!(self, cell_name, allocate, request)
     }
 
     #[tracing::instrument(skip(self))]
@@ -160,26 +145,12 @@ impl CellService {
     ) -> Result<CellServiceFreeResponse> {
         let ValidatedCellServiceFreeRequest { cell_name } = request;
 
-        let (cell_name, empty) = cell_name.into_child().expect("not empty");
+        info!("CellService: free() cell_name={cell_name:?}");
 
-        // There should have been a single cell name in the path.
-        // Otherwise, we should have called free_in_cell
-        assert!(matches!(empty, CellNamePath::Empty));
-
-        info!("CellService: free() cell_name={:?}", cell_name);
         let mut cells = self.cells.lock().await;
         cells.free(&cell_name)?;
 
         Ok(CellServiceFreeResponse::default())
-    }
-
-    #[tracing::instrument(skip(self))]
-    async fn free_in_cell(
-        &self,
-        cell_name: &CellName,
-        request: CellServiceFreeRequest,
-    ) -> std::result::Result<Response<CellServiceFreeResponse>, Status> {
-        do_in_cell!(self, cell_name, free, request)
     }
 
     #[tracing::instrument(skip(self))]
@@ -202,7 +173,7 @@ impl CellService {
         let ValidatedCellServiceStartRequest { cell_name, executable } =
             request;
 
-        assert!(matches!(cell_name, CellNamePath::Empty));
+        assert!(matches!(cell_name, None));
         info!("CellService: start() executable={:?}", executable);
 
         let mut executables = self.executables.lock().await;
@@ -239,7 +210,7 @@ impl CellService {
         let ValidatedCellServiceStopRequest { cell_name, executable_name } =
             request;
 
-        assert!(matches!(cell_name, CellNamePath::Empty));
+        assert!(matches!(cell_name, None));
         info!("CellService: stop() executable_name={:?}", executable_name,);
 
         let mut executables = self.executables.lock().await;
@@ -278,38 +249,12 @@ impl cell_service_server::CellService for CellService {
     ) -> std::result::Result<Response<CellServiceAllocateResponse>, Status>
     {
         let request = request.into_inner();
+        let request = ValidatedCellServiceAllocateRequest::validate(
+            request.clone(),
+            None,
+        )?;
 
-        // We execute allocate if cell_name is a direct child
-        if matches!(&request.cell, Some(cell) if !cell.name.contains(cell_name_path::SEPARATOR))
-        {
-            let request = ValidatedCellServiceAllocateRequest::validate(
-                request.clone(),
-                None,
-            )?;
-
-            Ok(Response::new(self.allocate(request).await?))
-        } else {
-            let validated = ValidatedCellServiceAllocateRequest::validate(
-                request.clone(),
-                None,
-            )?;
-
-            // validation has succeed, so we can make assumptions about the request and use expect
-            let (parent, cell_name) = validated
-                .cell
-                .name
-                .into_child()
-                .expect("CellNamePath was not empty");
-
-            let mut request = request;
-            if let Some(cell) = &mut request.cell {
-                cell.name = cell_name.into_string();
-            } else {
-                unreachable!("validation should have failed")
-            }
-
-            self.allocate_in_cell(&parent, request).await
-        }
+        Ok(Response::new(self.allocate(request).await?))
     }
 
     async fn free(
@@ -317,31 +262,10 @@ impl cell_service_server::CellService for CellService {
         request: Request<CellServiceFreeRequest>,
     ) -> std::result::Result<Response<CellServiceFreeResponse>, Status> {
         let request = request.into_inner();
+        let request =
+            ValidatedCellServiceFreeRequest::validate(request.clone(), None)?;
 
-        // We execute free if cell_name is a direct child
-        if !request.cell_name.contains(cell_name_path::SEPARATOR) {
-            let request = ValidatedCellServiceFreeRequest::validate(
-                request.clone(),
-                None,
-            )?;
-            Ok(Response::new(self.free(request).await?))
-        } else {
-            let validated = ValidatedCellServiceFreeRequest::validate(
-                request.clone(),
-                None,
-            )?;
-
-            // validation has succeeded, so we can make assumptions about the request and use expect
-            let mut request = request;
-            let (parent, cell_name) = validated
-                .cell_name
-                .into_child()
-                .expect("CellNamePath was not empty");
-
-            request.cell_name = cell_name.into_string();
-
-            self.free_in_cell(&parent, request).await
-        }
+        Ok(Response::new(self.free(request).await?))
     }
 
     async fn start(
@@ -350,8 +274,8 @@ impl cell_service_server::CellService for CellService {
     ) -> std::result::Result<Response<CellServiceStartResponse>, Status> {
         let request = request.into_inner();
 
-        // We execute start if cell_name is empty
-        if request.cell_name.is_empty() {
+        // We execute start if cell_name is none
+        if request.cell_name.is_none() {
             let request =
                 ValidatedCellServiceStartRequest::validate(request, None)?;
             Ok(self.start(request).await?)
@@ -362,16 +286,11 @@ impl cell_service_server::CellService for CellService {
                 None,
             )?;
 
-            // validation has succeed, so we can make assumptions about the request and use expect
+            // validation has succeeded, so we can make assumptions about the request and use expect
+            let cell_name = validated.cell_name.expect("cell name");
             let mut request = request;
-            let (parent, cell_name) = validated
-                .cell_name
-                .into_child()
-                .expect("CellNamePath was not empty");
-
-            request.cell_name = cell_name.into_string();
-
-            self.start_in_cell(&parent, request).await
+            request.cell_name = None;
+            self.start_in_cell(&cell_name, request).await
         }
     }
 
@@ -381,9 +300,8 @@ impl cell_service_server::CellService for CellService {
     ) -> std::result::Result<Response<CellServiceStopResponse>, Status> {
         let request = request.into_inner();
 
-        // We execute stop if cell_name is empty.
-        // Otherwise, we execute in a child
-        if request.cell_name.is_empty() {
+        // We execute stop if cell_name is none
+        if request.cell_name.is_none() {
             let request =
                 ValidatedCellServiceStopRequest::validate(request, None)?;
             Ok(self.stop(request).await?)
@@ -394,16 +312,11 @@ impl cell_service_server::CellService for CellService {
                 None,
             )?;
 
-            // validation has succeed, so we can make assumptions about the request and use expect
+            // validation has succeeded, so we can make assumptions about the request and use expect
+            let cell_name = validated.cell_name.expect("cell name");
             let mut request = request;
-            let (parent, cell_name) = validated
-                .cell_name
-                .into_child()
-                .expect("CellNamePath was not empty");
-
-            request.cell_name = cell_name.into_string();
-
-            self.stop_in_cell(&parent, request).await
+            request.cell_name = None;
+            self.stop_in_cell(&cell_name, request).await
         }
     }
 }

--- a/auraed/src/runtime/cell_service/cells/cell_name.rs
+++ b/auraed/src/runtime/cell_service/cells/cell_name.rs
@@ -1,18 +1,58 @@
+use iter_tools::Itertools;
+use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
-use std::ops::Deref;
+use std::path::{Path, PathBuf};
 use validation::{ValidatedField, ValidationError};
 
+pub const SEPARATOR: char = '/';
+
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub struct CellName(String);
+pub struct CellName(PathBuf);
 
 impl CellName {
-    pub fn into_inner(self) -> String {
+    pub fn leaf(&self) -> Cow<str> {
         self.0
+            .components()
+            .last()
+            .expect("non empty path")
+            .as_os_str()
+            .to_string_lossy()
+    }
+
+    pub fn to_root(&self) -> CellName {
+        let root = self.0.components().find_or_first(|_| true).expect("root");
+        Self(PathBuf::from(root.as_os_str()))
+    }
+
+    pub fn to_child(&self, descendant: &CellName) -> CellName {
+        assert!(descendant.0.starts_with(self.0.as_path()));
+        let path = self.0.join(descendant.to_root().0);
+        Self(path)
+    }
+
+    pub fn is_child(&self, parent: Option<&CellName>) -> bool {
+        let self_parent = self.0.parent().filter(|x| !x.as_os_str().is_empty());
+
+        match (self_parent, parent) {
+            (None, None) => true,
+            (None, _) | (_, None) => false,
+            (Some(self_parent), Some(parent)) => {
+                self_parent == parent.0.as_path()
+            }
+        }
+    }
+
+    pub fn into_inner(self) -> PathBuf {
+        self.0
+    }
+
+    pub fn as_inner(&self) -> &Path {
+        self.0.as_path()
     }
 
     #[cfg(test)]
     pub fn random_for_tests() -> Self {
-        Self(format!("ae-test-{}", uuid::Uuid::new_v4().to_string()))
+        Self(PathBuf::from(format!("ae-test-{}", uuid::Uuid::new_v4())))
     }
 }
 
@@ -25,43 +65,30 @@ impl ValidatedField<String> for CellName {
         let input =
             validation::required_not_empty(input, field_name, parent_name)?;
 
+        // Opting to be forgiving of paths that start or end with SEPARATOR
+        let input = input.trim_matches(SEPARATOR);
+
+        let input = input
+            .split(SEPARATOR)
+            .flat_map(|component| {
+                validation::allow_regex(
+                    component,
+                    &validation::DOMAIN_NAME_LABEL_REGEX,
+                    field_name,
+                    parent_name,
+                )?;
+
+                Ok::<_, ValidationError>(component)
+            })
+            .collect();
+
         Ok(Self(input))
-    }
-
-    fn validate_for_creation(
-        input: Option<String>,
-        field_name: &str,
-        parent_name: Option<&str>,
-    ) -> Result<Self, ValidationError> {
-        let input = Self::validate(input, field_name, parent_name)?;
-
-        // TODO: what makes a valid cgroup name
-        // any valid path?
-        // do we want a restriction on length?
-        // anything else?
-        // Highly restrictive for now:
-        validation::allow_regex(
-            &input,
-            &validation::DOMAIN_NAME_LABEL_REGEX,
-            field_name,
-            parent_name,
-        )?;
-
-        Ok(input)
-    }
-}
-
-impl Deref for CellName {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 
 impl Display for CellName {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        self.0.display().fmt(f)
     }
 }
 

--- a/auraed/src/runtime/cell_service/cells/mod.rs
+++ b/auraed/src/runtime/cell_service/cells/mod.rs
@@ -30,17 +30,17 @@
 
 use cell::Cell;
 pub use cell_name::CellName;
-pub use cell_name_path::CellNamePath;
 pub use cells::Cells;
+pub use cells_cache::CellsCache;
 use cgroups::CgroupSpec;
 pub use error::{CellsError, Result};
 pub use nested_auraed::IsolationControls;
 
 mod cell;
 mod cell_name;
-pub mod cell_name_path;
 #[allow(clippy::module_inception)]
 mod cells;
+mod cells_cache;
 pub mod cgroups;
 mod error;
 mod nested_auraed;

--- a/auraed/src/runtime/cell_service/cells/nested_auraed/isolation_controls.rs
+++ b/auraed/src/runtime/cell_service/cells/nested_auraed/isolation_controls.rs
@@ -45,8 +45,8 @@ pub(crate) struct Isolation {
 }
 
 impl Isolation {
-    pub fn new(name: &str) -> Isolation {
-        Isolation { name: name.to_string() }
+    pub fn new(name: String) -> Isolation {
+        Isolation { name }
     }
     pub fn setup(&mut self, iso_ctl: &IsolationControls) -> io::Result<()> {
         // The only setup we will need to do is for isolate_process at this time.

--- a/auraed/src/runtime/cell_service/cells/nested_auraed/nested_auraed.rs
+++ b/auraed/src/runtime/cell_service/cells/nested_auraed/nested_auraed.rs
@@ -53,7 +53,7 @@ pub struct NestedAuraed {
 }
 
 impl NestedAuraed {
-    pub fn new(name: &str, iso_ctl: IsolationControls) -> io::Result<Self> {
+    pub fn new(name: String, iso_ctl: IsolationControls) -> io::Result<Self> {
         // Here we launch a nested auraed with the --nested flag
         // which is used our way of "hooking" into the newly created
         // aurae isolation zone.

--- a/auraed/src/runtime/cell_service/executables/executable.rs
+++ b/auraed/src/runtime/cell_service/executables/executable.rs
@@ -50,6 +50,7 @@ impl Executable {
         };
 
         let mut child = command
+            .kill_on_drop(true)
             .current_dir("/")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/auraed/src/runtime/cell_service/executables/executables.rs
+++ b/auraed/src/runtime/cell_service/executables/executables.rs
@@ -108,4 +108,17 @@ impl Executables {
 
         Ok(exit_status)
     }
+
+    /// Stops all executables concurrently
+    pub async fn broadcast_stop(&mut self) {
+        let mut names = vec![];
+        for exe in self.cache.values_mut() {
+            let _ = exe.kill().await;
+            names.push(exe.name.clone())
+        }
+
+        for name in names {
+            let _ = self.cache.remove(&name);
+        }
+    }
 }


### PR DESCRIPTION
We are having issues with nesting cells at a depth greater than 1. This PR is meant to fix that.

The issue stems from the "no internal processes" rule for v2 [cgroups](https://man7.org/linux/man-pages/man7/cgroups.7.html). 
> ...with the exception of the root cgroup, processes may reside only in leaf nodes (cgroups that do not themselves contain child cgroups).

Essentially, our nested auraeds, themselves a process, are not allowed to create cgroups. With this PR, only the root auraed will be responsible for creating cgroups, and the nested auraed will be responsible for spawning executables.

I'm want to use this PR to also fix graceful shutdown. We haven't been shutting down the spawned executables, which is causing issues with cleaning up the cgroups.

---

edit: `GracefulShutdown` now broadcasts stop to all executables (which sends a SIGKILL), allowing the cgroup. to be cleaned up.

---

NOTE: The api for `CellService`'s start and stop has been updated, making `cell_name` optional. A null `cell_name` means auraed should spawn the process in its own cgroup. For the auraed that is true pid 1, that means the executable is not in a cell (it is in the root cgroup).