### PR TITLE
Update makefile for more efficient cargo use

### DIFF
--- a/.github/workflows/001-cargo-test-ubuntu-make-test.yml
+++ b/.github/workflows/001-cargo-test-ubuntu-make-test.yml
@@ -93,9 +93,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-      - name: Cargo Install [make install]
+      - name: Cargo build, lint, test [make test]
         # This should remain the only command we execute as this matches the title of the file.
         # The goal is for this to be easy to find from the GitHub dashboard.
         # Instead of adding more commands here, consider another make target or a new YAML file
         # named with a good name.
-        run: make install
+        run: make test

--- a/.github/workflows/050-release-ubuntu-make-ci-upload-release-artifacts.yml
+++ b/.github/workflows/050-release-ubuntu-make-ci-upload-release-artifacts.yml
@@ -53,6 +53,6 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Make, stage, upload release artifacts
-              run: make ci-release tag=$GITHUB_REF_NAME
+              run: make ci-upload-release-artifacts tag=$GITHUB_REF_NAME
               env:
                 GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Updated the makefile taking into consideration the following (also in the makefile):

- make will not run the same step multiple times
- The ideal order for cargo to reuse artifacts is build -> lint -> test
- Different cargo target variants (nightly is a variant) do not produce compatible artifacts
- Cargo's `install` artifacts are not usable for build, lint, or test (and vice versa)

This PR also updates the workflows affected:
- 001, runs build -> lint -> test. Was lint -> test -> install
- 050, uses build instead of install which should speed it up