### PR TITLE
Fix: Correctly create a child `CellName` in `CellName::to_child`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ auraed-test: musl proto
 auraed-test-all: musl proto
 	@sudo -E $(cargo) test --target $(uname_m)-unknown-linux-musl -p auraed -- --include-ignored
 
+.PHONY: auraed-test-watch
+auraed-test-watch: musl proto # Use cargo-watch to continuously run a test (e.g. make auared-test-watch name=path::to::test)
+	@sudo -E $(cargo) watch -- $(cargo) test --target $(uname_m)-unknown-linux-musl -p auraed $(name) -- --include-ignored
+
 .PHONY: auraed-build
 auraed-build: musl proto
 	@$(cargo) build --target $(uname_m)-unknown-linux-musl -p auraed

--- a/auraed/src/cells/cell_service/cells/cells.rs
+++ b/auraed/src/cells/cell_service/cells/cells.rs
@@ -39,7 +39,7 @@ macro_rules! proxy_if_needed {
             // we are not in the direct parent
             let child_cell_name = match &$self.parent {
                 None => $cell_name.to_root(),
-                Some(parent) => parent.to_child(&$cell_name),
+                Some(parent) => parent.to_child(&$cell_name).expect("child CellName"),
             };
 
             // we require that all ancestor cells exist


### PR DESCRIPTION
When nesting cells multiple levels, the child `CellName` was not correct. For example, if you had "grandparent-cell" and "grandparent-cell/parent-cell/child-cell", the result of `to_child` would be "grandparent-cell/grandparent-cell". This fixes that so that we get "grandparent-cell/parent-cell".

I also added a make command that uses cargo-watch to make developing with tests more convenient. Example usage...
```bash
make auraed-test-watch name=cells::cell_service::cells::cell_name::tests::test_to_child
```
Then every time cargo-watch detects changes to the source files, it will rerun that specific test automatically. To install cargo-watch run `cargo install cargo-watch`.