### PR TITLE
Remove ignore requirement for tests needing root privileges

### DIFF
--- a/.github/workflows/101-tester-aurae-builder-make-pki-config-test.yml
+++ b/.github/workflows/101-tester-aurae-builder-make-pki-config-test.yml
@@ -64,9 +64,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: build-compile-test-container-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cargo Test [make test]
+      - name: Cargo Test [make pki config test]
         # This should remain the only command we execute as this matches the title of the file.
         # The goal is for this to be easy to find from the GitHub dashboard.
         # Instead of adding more commands here, consider another make target or a new YAML file
         # named with a good name.
-        run: make test
+        run: make pki config test

--- a/.github/workflows/201-tester-aurae-builder-make-pki-config-test.yml
+++ b/.github/workflows/201-tester-aurae-builder-make-pki-config-test.yml
@@ -1,0 +1,72 @@
+# ---------------------------------------------------------------------------- #
+#        Apache 2.0 License Copyright © 2022-2023 The Aurae Authors            #
+#                                                                              #
+#                +--------------------------------------------+                #
+#                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |                #
+#                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |                #
+#                |  ███████║██║   ██║██████╔╝███████║█████╗   |                #
+#                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |                #
+#                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |                #
+#                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |                #
+#                +--------------------------------------------+                #
+#                                                                              #
+#                         Distributed Systems Runtime                          #
+#                                                                              #
+# ---------------------------------------------------------------------------- #
+#                                                                              #
+#   Licensed under the Apache License, Version 2.0 (the "License");            #
+#   you may not use this file except in compliance with the License.           #
+#   You may obtain a copy of the License at                                    #
+#                                                                              #
+#       http://www.apache.org/licenses/LICENSE-2.0                             #
+#                                                                              #
+#   Unless required by applicable law or agreed to in writing, software        #
+#   distributed under the License is distributed on an "AS IS" BASIS,          #
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+#   See the License for the specific language governing permissions and        #
+#   limitations under the License.                                             #
+#                                                                              #
+# ---------------------------------------------------------------------------- #
+#
+name: "Tester (201) [aurae-builder:tester-latest]"
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+permissions:
+  contents: read
+  packages: write
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  build-container:
+    uses: ./.github/workflows/200-aurae-builder-image-docker-build-tester.yml
+  build:
+    name: Build (lint, compile, test)
+    runs-on: ubuntu-latest
+    needs: build-container
+    timeout-minutes: 20
+    container:
+      image: ghcr.io/${{ github.repository }}/aurae-builder:tester-latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: build-compile-test-container-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cargo Test [make pki config test]
+        # This should remain the only command we execute as this matches the title of the file.
+        # The goal is for this to be easy to find from the GitHub dashboard.
+        # Instead of adding more commands here, consider another make target or a new YAML file
+        # named with a good name.
+        run: make pki config test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "rtnetlink",
  "simple_test_case",
  "simplelog",
+ "test-helpers",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3347,6 +3348,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-helpers"
+version = "0.0.0"
+dependencies = [
+ "nix 0.26.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ aurae-proto = { path = "./aurae-proto" }
 fancy-regex = "0.10.0"
 heck = "0.4.0"
 lazy_static = "1.4.0"
+nix = "0.26.1"
 proc-macro2 = "1.0"
 protobuf = "3.2.0"
 protobuf-parse = "=3.2.0" # This crate makes no promises of stabilty, so we pin to the exact version
@@ -52,6 +53,7 @@ quote = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 syn = { version = "1.0", features = ["full"] } # used in macros, so full doesn't affect binary size
+test-helpers = { path = "./crates/test-helpers" }
 thiserror = "1.0.37"
 tokio = "1.22.0"
 tonic = "0.8.2"

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -57,7 +57,7 @@ libcontainer = { git = "https://github.com/krisnova/youki", branch = "musl-libco
 liboci-cli = "0.0.4"
 log = "0.4.17"
 netlink-packet-route = "0.13.0" # Used for netlink_packet_route::rtnl::address::nlas definition
-nix = { version = "0.26.1", features = ["sched"] }
+nix = { workspace = true, features = ["sched"] }
 ocipkg = "0.2.8"
 procfs = "0.14.2"
 rtnetlink = "0.11.0"
@@ -79,3 +79,4 @@ multi_log = "0.1.2"
 
 [dev-dependencies]
 simple_test_case = "1.1.0"
+test-helpers = { workspace = true }

--- a/auraed/src/cells/cell_service/cells/cell.rs
+++ b/auraed/src/cells/cell_service/cells/cell.rs
@@ -258,11 +258,12 @@ impl Drop for Cell {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_helpers::*;
 
-    // Ignored: requires sudo, which we don't have in CI
-    #[ignore]
     #[test]
     fn test_cant_unfree() {
+        skip_if_not_root!("test_cant_unfree");
+
         let cell_name = CellName::random_for_tests();
         let mut cell = Cell::new(cell_name, CellSpec::new_for_tests());
         assert!(matches!(cell.state, CellState::Unallocated));

--- a/auraed/src/cells/cell_service/cells/cells.rs
+++ b/auraed/src/cells/cell_service/cells/cells.rs
@@ -271,11 +271,12 @@ impl CellsCache for Cells {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_helpers::*;
 
-    // Ignored: requires sudo, which we don't have in CI
-    #[ignore]
     #[test]
     fn test_allocate() {
+        skip_if_not_root!("test_allocate");
+
         let mut cells = Cells::default();
         assert!(cells.cache.is_empty());
 
@@ -286,10 +287,10 @@ mod tests {
         assert!(cells.cache.contains_key(&cell_name));
     }
 
-    // Ignored: requires sudo, which we don't have in CI
-    #[ignore]
     #[test]
     fn test_duplicate_allocate_is_error() {
+        skip_if_not_root!("test_duplicate_allocate_is_error");
+
         let mut cells = Cells::default();
         assert!(cells.cache.is_empty());
 
@@ -307,10 +308,10 @@ mod tests {
         ));
     }
 
-    // Ignored: requires sudo, which we don't have in CI
-    #[ignore]
     #[test]
     fn test_get() {
+        skip_if_not_root!("test_get");
+
         let mut cells = Cells::default();
         assert!(cells.cache.is_empty());
 
@@ -336,10 +337,10 @@ mod tests {
         ));
     }
 
-    // Ignored: requires sudo, which we don't have in CI
-    #[ignore]
     #[test]
     fn test_free() {
+        skip_if_not_root!("test_free");
+
         let mut cells = Cells::default();
         assert!(cells.cache.is_empty());
 

--- a/crates/test-helpers/Cargo.toml
+++ b/crates/test-helpers/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test-helpers"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+nix = { workspace = true }

--- a/crates/test-helpers/src/lib.rs
+++ b/crates/test-helpers/src/lib.rs
@@ -1,0 +1,77 @@
+/* -------------------------------------------------------------------------- *\
+ *        Apache 2.0 License Copyright © 2022-2023 The Aurae Authors          *
+ *                                                                            *
+ *                +--------------------------------------------+              *
+ *                |   █████╗ ██╗   ██╗██████╗  █████╗ ███████╗ |              *
+ *                |  ██╔══██╗██║   ██║██╔══██╗██╔══██╗██╔════╝ |              *
+ *                |  ███████║██║   ██║██████╔╝███████║█████╗   |              *
+ *                |  ██╔══██║██║   ██║██╔══██╗██╔══██║██╔══╝   |              *
+ *                |  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ |              *
+ *                |  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ |              *
+ *                +--------------------------------------------+              *
+ *                                                                            *
+ *                         Distributed Systems Runtime                        *
+ *                                                                            *
+ * -------------------------------------------------------------------------- *
+ *                                                                            *
+ *   Licensed under the Apache License, Version 2.0 (the "License");          *
+ *   you may not use this file except in compliance with the License.         *
+ *   You may obtain a copy of the License at                                  *
+ *                                                                            *
+ *       http://www.apache.org/licenses/LICENSE-2.0                           *
+ *                                                                            *
+ *   Unless required by applicable law or agreed to in writing, software      *
+ *   distributed under the License is distributed on an "AS IS" BASIS,        *
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ *   See the License for the specific language governing permissions and      *
+ *   limitations under the License.                                           *
+ *                                                                            *
+\* -------------------------------------------------------------------------- */
+
+// Lint groups: https://doc.rust-lang.org/rustc/lints/groups.html
+#![warn(future_incompatible, nonstandard_style, unused)]
+#![warn(
+    improper_ctypes,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    unconditional_recursion,
+    unused_comparisons,
+    while_true
+)]
+#![warn(missing_debug_implementations,
+// TODO: missing_docs,
+trivial_casts,
+trivial_numeric_casts,
+unused_extern_crates,
+unused_import_braces,
+unused_qualifications,
+unused_results
+)]
+#![warn(clippy::unwrap_used)]
+#![allow(unused_qualifications)]
+
+// Nix has a collection of test helpers that are not exposed publicly by their crate
+// The below skip helpers are here: https://github.com/nix-rust/nix/blob/master/test/common/mod.rs
+
+#[macro_export]
+macro_rules! skip {
+    ($($reason: expr),+) => {
+        use ::std::io::{self, Write};
+
+        let stderr = io::stderr();
+        let mut handle = stderr.lock();
+        writeln!(handle, $($reason),+).unwrap();
+        return;
+    }
+}
+
+#[macro_export]
+macro_rules! skip_if_not_root {
+    ($name:expr) => {
+        use nix::unistd::Uid;
+
+        if !Uid::current().is_root() {
+            skip!("{} requires root privileges. Skipping test.", $name);
+        }
+    };
+}

--- a/images/Dockerfile.test
+++ b/images/Dockerfile.test
@@ -53,6 +53,7 @@ RUN  apt-get update && \
     protobuf-compiler \
     git \
     python3-pip \
+    libseccomp-dev \
     libssl-dev \
     openssl \
     pkg-config


### PR DESCRIPTION
We've been marking tests that need sudo (root privileges) with ignore, so that we can run the tests in CI.

I noticed the Nix crate had some helpful macros, circumventing the need to use ignore. They aren't part of their public api, so I created a `test-helpers` crate for us and copied the 2 macros we needed to skip when root isn't available.  