### PR TITLE
Don't run `buf generate` if api directory is unchanged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf-buffer"
+version = "0.0.0"
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "auraescript",
     "aurae-client",
     "aurae-proto",
+    "crates/buf-buffer",
 ]
 
 [workspace.dependencies]

--- a/Makefile
+++ b/Makefile
@@ -136,13 +136,16 @@ clean-gens: ## Clean gen directories
 # Protobuf Commands
 
 .PHONY: proto
-proto: proto-lint ## Lint and Generate code from protobuf schemas
-	@buf --version >/dev/null 2>&1 || (echo "Warning: buf is not installed! Please install the 'buf' command line tool: https://docs.buf.build/installation"; exit 1)
-	buf generate -v api
+proto: proto-buf proto-lint ## Lint and Generate code from protobuf schemas
+	$(cargo) build -p buf-buffer
 
 .PHONY: proto-lint
-proto-lint: ## Lint protobuf schemas
+proto-lint: proto-buf ## Lint protobuf schemas
 	buf lint api
+
+.PHONY: proto-lint
+proto-buf: ## Check that buf cli is installed
+	@buf --version >/dev/null 2>&1 || (echo "Warning: buf is not installed! Please install the 'buf' command line tool: https://docs.buf.build/installation"; exit 1)
 
 .PHONY: proto-vendor
 proto-vendor: proto-vendor-cri proto-vendor-grpc-health ## Copy the upstream protobuf interfaces

--- a/crates/buf-buffer/Cargo.toml
+++ b/crates/buf-buffer/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "buf-buffer"
+version = "0.0.0"
+edition = "2021"
+publish = false

--- a/crates/buf-buffer/build.rs
+++ b/crates/buf-buffer/build.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+
+/// Will run `buf generate` when a file in the api directory changes.
+fn main() {
+    println!("cargo:rerun-if-changed=../../api");
+
+    Command::new("buf")
+        .args(["--version"])
+        .output()
+        .expect("Warning: buf is not installed! Please install the 'buf' command line tool: https://docs.buf.build/installation");
+
+    Command::new("buf")
+        .args([
+            "generate",
+            "../../api",
+            "-v",
+            "--template",
+            "../../buf.gen.yaml",
+            "-o",
+            "../../",
+        ])
+        .output()
+        .expect("`buf generate` failed");
+}

--- a/crates/buf-buffer/src/main.rs
+++ b/crates/buf-buffer/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!(
+        "This binary is not meant to be run. Its build script is what we want."
+    );
+}


### PR DESCRIPTION
Currently, our makefile will run `buf generate` even when the files in the api directory are unchanged. This PR prevents `buf generate` from running when nothing has changed by leveraging a rust build.rs and cargo's rerun hints.

The benefit is that for local development, crates that depend on the output of `buf generate` will have a better chance of caching their builds.

The drawback is that if someone alters the generated files, `buf generate` won't run to revert the changes. They would need to run `make clean` first. 