### PR TITLE
ensure we only run buf when we need to

### DIFF
--- a/.github/workflows/207-udeps-check-aurae-builder-make-check-deps.yml
+++ b/.github/workflows/207-udeps-check-aurae-builder-make-check-deps.yml
@@ -66,7 +66,5 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
-      - name: Make proto [make proto]
-        run: make proto
       - name: Cargo udeps [make check-deps]
         run: make check-deps

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ GEN_RS += $(patsubst api/v0/%,$(GEN_TONIC_RS_PATTERN),$(PROTO_DIRS))
 
 GEN_TS = $(patsubst api/v0/%.proto,$(GEN_TS_PATTERN),$(PROTOS))
 
-$(GEN_TS_PATTERN) $(GEN_RS_PATTERN) $(GEN_SERDE_RS_PATTERN) $(GEN_TONIC_RS_PATTERN):
+$(GEN_TS_PATTERN) $(GEN_RS_PATTERN) $(GEN_SERDE_RS_PATTERN) $(GEN_TONIC_RS_PATTERN): $(PROTOS)
 	buf lint api
 	buf generate -v api
 

--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ help:  ## Show help messages for make targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: check-deps
-check-deps: musl ## Check if there are any unused dependencies in Cargo.toml
+check-deps: musl $(GEN_TS) $(GEN_RS) ## Check if there are any unused dependencies in Cargo.toml
 #	cargo +nightly udeps --target $(uname_m)-unknown-linux-musl --package auraed
 #	cargo +nightly udeps --package auraescript
 #	cargo +nightly udeps --package aurae-client

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ all: install ## alias for install
 clean: clean-certs clean-gens clean-crates ## Clean the repo
 
 .PHONY: lint
-lint: musl $(GEN_RS) $(GEN_TS) libs-lint auraed-lint auraescript-lint aer-lint ## Run all lints
+lint: musl libs-lint auraed-lint auraescript-lint aer-lint ## Run all lints
 
 .PHONY: test
 test: build lint libs-test auraed-test auraescript-test aer-test ## Builds, lints, and tests (does not include ignored tests)
@@ -72,13 +72,13 @@ test: build lint libs-test auraed-test auraescript-test aer-test ## Builds, lint
 test-all: build lint libs-test-all auraed-test-all auraescript-test-all aer-test-all ## Run lints and tests (includes ignored tests)
 
 .PHONY: build
-build: musl $(GEN_RS) $(GEN_TS) auraed-build auraescript-build aer-build lint ## Build and lint
+build: musl auraed-build auraescript-build aer-build lint ## Build and lint
 
 .PHONY: install
-install: musl $(GEN_RS) $(GEN_TS) lint test auraed-debug auraescript-debug aer-debug  ## Lint, test, and install (debug) 🎉
+install: musl lint test auraed-debug auraescript-debug aer-debug  ## Lint, test, and install (debug) 🎉
 
 .PHONY: docs
-docs: $(GEN_RS) $(GEN_TS) docs-crates docs-stdlib docs-other ## Assemble all the /docs for the website locally.
+docs: docs-crates docs-stdlib docs-other ## Assemble all the /docs for the website locally.
 
 .PHONY: prcheck
 prcheck: build lint test-all docs docs-lint ## Meant to mimic the GHA checks (includes ignored tests)
@@ -307,13 +307,13 @@ ifeq (, $(wildcard /usr/local/bin/protoc-gen-doc))
 docs-stdlib:
 	$(error "No /usr/local/bin/protoc-gen-doc, install from https://github.com/pseudomuto/protoc-gen-doc")
 else
-docs-stdlib:
+docs-stdlib: $(GEN_TS) $(GEN_RS)
 	protoc --plugin=/usr/local/bin/protoc-gen-doc -I api/v0/discovery -I api/v0/observe -I api/v0/cells --doc_out=docs/stdlib/v0 --doc_opt=markdown,index.md:Ignore* api/v0/*/*.proto --experimental_allow_proto3_optional
 endif
 
 
 .PHONY: docs-crates
-docs-crates: musl ## Build the crate (documentation)
+docs-crates: musl $(GEN_TS) $(GEN_RS) ## Build the crate (documentation)
 	$(cargo) doc --target $(uname_m)-unknown-linux-musl --no-deps --package auraed
 	$(cargo) doc --no-deps --package auraescript
 	$(cargo) doc --no-deps --package aurae-client


### PR DESCRIPTION
this change creates some pattern matches between the input protos and the expected outputs (rust and typescript).  it then defines a rule that runs buf if any of the outputs are missing.

this means that make will only run buf when necessary and, because the first run creates all the files, will only run it once. 