### PR TITLE
Port to libcgroups crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,6 @@ dependencies = [
  "aurae-client",
  "aurae-proto",
  "backoff",
- "cgroups-rs",
  "clap 4.1.4",
  "clone3",
  "fancy-regex",
@@ -191,12 +190,15 @@ dependencies = [
  "iter_tools",
  "lazy_static",
  "libc",
+ "libcgroups 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libcontainer",
  "liboci-cli",
  "log",
  "multi_log",
  "netlink-packet-route",
+ "nix 0.25.1",
  "nix 0.26.2",
+ "oci-spec 0.5.8",
  "oci-spec 0.6.0",
  "ocipkg",
  "procfs",
@@ -446,19 +448,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cgroups-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b97b639839204a6eb727ffbbd68e1dcfc55488c3a26cb0cda1d662b7a186e79"
-dependencies = [
- "libc",
- "log",
- "nix 0.25.1",
- "regex",
- "thiserror",
-]
 
 [[package]]
 name = "chrono"
@@ -1603,6 +1592,21 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 [[package]]
 name = "libcgroups"
 version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7da5afffc27b9cdef1e65e377b39f30bbe0c6224b9bd2e590ccb400134280d"
+dependencies = [
+ "anyhow",
+ "fixedbitset",
+ "log",
+ "nix 0.25.1",
+ "oci-spec 0.5.8",
+ "procfs",
+ "serde",
+]
+
+[[package]]
+name = "libcgroups"
+version = "0.0.4"
 source = "git+https://github.com/krisnova/youki?branch=musl-libcontainer#cc2a4d0fdd5d7f2c05a218322a0c8bfd0ea22fdf"
 dependencies = [
  "anyhow",
@@ -1627,7 +1631,7 @@ dependencies = [
  "fastrand",
  "futures",
  "libc",
- "libcgroups",
+ "libcgroups 0.0.4 (git+https://github.com/krisnova/youki?branch=musl-libcontainer)",
  "log",
  "mio",
  "nix 0.25.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,9 +197,7 @@ dependencies = [
  "multi_log",
  "netlink-packet-route",
  "nix 0.25.1",
- "nix 0.26.2",
  "oci-spec 0.5.8",
- "oci-spec 0.6.0",
  "ocipkg",
  "procfs",
  "rtnetlink",
@@ -3339,7 +3337,7 @@ dependencies = [
 name = "test-helpers"
 version = "0.0.0"
 dependencies = [
- "nix 0.26.2",
+ "nix 0.25.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ clap = { version = "4.1.1", features = ["derive"] }
 fancy-regex = "0.10.0"
 heck = "0.4.0"
 lazy_static = "1.4.0"
-nix = "0.26.1"
+nix = "0.25" # upgrade to 0.26 blocked by libcgroups as of v0.0.4
 proc-macro2 = "1.0"
 protobuf = "3.2.0"
 protobuf-parse = "=3.2.0" # This crate makes no promises of stabilty, so we pin to the exact version

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -59,10 +59,8 @@ log = "0.4.17"
 multi_log = "0.1.2"
 netlink-packet-route = "0.13.0" # Used for netlink_packet_route::rtnl::address::nlas definition
 nix = { workspace = true, features = ["sched"] }
-nix_025 = { package = "nix", version = "0.25" } # needed for libcgroups as of v0.0.4
 ocipkg = "0.2.8"
-oci-spec = "0.6.0"
-oci-spec-05 = { package = "oci-spec", version = "0.5" } # needed for libcgroups as of v0.0.4
+oci-spec = "0.5" # upgrade to 0.6 blocked by libcgroups as of v0.0.4
 procfs = "0.14.2"
 rtnetlink = "0.11.0"
 serde_json.workspace = true

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -44,7 +44,6 @@ anyhow = { workspace = true }
 aurae-client = { workspace = true }
 aurae-proto = { workspace = true }
 backoff = { version = "0.4.0", features = ["tokio"] }
-cgroups-rs = "0.3.0"
 clap = { workspace = true }
 clone3 = "0.2.3"
 fancy-regex = { workspace = true }
@@ -53,14 +52,17 @@ ipnetwork = "0.20.0"
 iter_tools = "0.1.4"
 libc = "0.2" # TODO: Nix comes with libc, can we rely on that?
 lazy_static = { workspace = true }
+libcgroups = { version = "0.0.4", default-features = false, features = ["v2"] }
 libcontainer = { git = "https://github.com/krisnova/youki", branch = "musl-libcontainer", features = ["v2"], default-features = false }
 liboci-cli = "0.0.4"
 log = "0.4.17"
 multi_log = "0.1.2"
 netlink-packet-route = "0.13.0" # Used for netlink_packet_route::rtnl::address::nlas definition
 nix = { workspace = true, features = ["sched"] }
+nix_025 = { package = "nix", version = "0.25" } # needed for libcgroups as of v0.0.4
 ocipkg = "0.2.8"
 oci-spec = "0.6.0"
+oci-spec-05 = { package = "oci-spec", version = "0.5" } # needed for libcgroups as of v0.0.4
 procfs = "0.14.2"
 rtnetlink = "0.11.0"
 serde_json.workspace = true

--- a/auraed/src/cells/cell_service/cells/cell.rs
+++ b/auraed/src/cells/cell_service/cells/cell.rs
@@ -114,8 +114,19 @@ impl Cell {
 
         let pid = auraed.pid();
 
-        let cgroup: Cgroup =
-            Cgroup::new(self.cell_name.clone(), self.spec.cgroup_spec.clone());
+        let cgroup = match Cgroup::new(
+            self.cell_name.clone(),
+            self.spec.cgroup_spec.clone(),
+        ) {
+            Ok(cgroup) => cgroup,
+            Err(e) => {
+                let _best_effort = auraed.kill();
+                return Err(CellsError::AbortedAllocateCell {
+                    cell_name: self.cell_name.clone(),
+                    source: e,
+                });
+            }
+        };
 
         if let Err(e) = cgroup.add_task(pid) {
             let _best_effort = auraed.kill();

--- a/auraed/src/cells/cell_service/cells/cell_name.rs
+++ b/auraed/src/cells/cell_service/cells/cell_name.rs
@@ -88,6 +88,7 @@ impl ValidatedField<String> for CellName {
         let input = input
             .split(SEPARATOR)
             .flat_map(|component| {
+                // NOTE: We must always reserve '/' (separator) and '_' (name of leaf cgroup)
                 validation::allow_regex(
                     component,
                     &validation::DOMAIN_NAME_LABEL_REGEX,

--- a/auraed/src/cells/cell_service/cells/cgroups/cgroup.rs
+++ b/auraed/src/cells/cell_service/cells/cgroups/cgroup.rs
@@ -38,7 +38,7 @@ use libcgroups::common::{CgroupManager, ControllerOpt, DEFAULT_CGROUP_ROOT};
 use libcgroups::stats::Stats;
 use libcgroups::v2;
 use nix::unistd::Pid;
-use oci_spec_05::runtime::{LinuxCpuBuilder, LinuxResourcesBuilder};
+use oci_spec::runtime::{LinuxCpuBuilder, LinuxResourcesBuilder};
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -148,7 +148,6 @@ impl Cgroup {
         )
         .expect("valid cgroup");
 
-        let pid = nix_025::unistd::Pid::from_raw(pid.as_raw());
         manager.add_task(pid).map_err(|e| CgroupsError::AddTaskToCgroup {
             cell_name: self.cell_name.clone(),
             source: e,

--- a/auraed/src/cells/cell_service/cells/cgroups/cgroup.rs
+++ b/auraed/src/cells/cell_service/cells/cgroups/cgroup.rs
@@ -32,9 +32,13 @@ use crate::cells::cell_service::cells::{
     cgroups::{CpuController, CpusetController},
     CellName, CgroupSpec,
 };
-use cgroups_rs::{cgroup_builder::CgroupBuilder, hierarchies, Hierarchy};
+use libcgroups::common::{CgroupManager, ControllerOpt, DEFAULT_CGROUP_ROOT};
+use libcgroups::stats::Stats;
+use libcgroups::v2;
 use nix::unistd::Pid;
+use oci_spec_05::runtime::{LinuxCpuBuilder, LinuxResourcesBuilder};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 /// This is used as the denominator for the CPU quota/period configuration.  This allows users to
 /// set the quota as if it was in the unit "µs/s" without worrying about also setting the period.
@@ -42,12 +46,11 @@ const MICROSECONDS_PER_SECOND: u64 = 1000000;
 
 #[derive(Debug)]
 pub struct Cgroup {
-    non_leaf: cgroups_rs::Cgroup,
-    leaf: cgroups_rs::Cgroup,
+    cell_name: CellName,
 }
 
 impl Cgroup {
-    pub fn new(cell_name: CellName, spec: CgroupSpec) -> Self {
+    pub fn new(cell_name: CellName, spec: CgroupSpec) -> anyhow::Result<Self> {
         let CgroupSpec { cpu, cpuset } = spec;
 
         // Note: Cgroups v2 "no internal processes" rule.
@@ -56,89 +59,144 @@ impl Cgroup {
         //        in leaf nodes (cgroups that do not themselves contain child cgroups)."
 
         // First we create the non-leaf cgroup using the spec
-        let mut name = cell_name.to_string();
-        let builder = CgroupBuilder::new(&name);
+        let builder = LinuxResourcesBuilder::default();
 
-        // cpu controller
-        let builder = if let Some(CpuController { weight, max }) = cpu {
-            let builder = builder.cpu();
+        // oci_spec, which libcgroups uses, combines the cpu and cpuset controllers
+        let builder = if cpu.is_some() || cpuset.is_some() {
+            let cpu_builder = LinuxCpuBuilder::default();
 
-            let builder = if let Some(weight) = weight {
-                builder.shares(weight.into_inner())
+            // cpu controller
+            let cpu_builder = if let Some(CpuController { weight, max }) = cpu {
+                let cpu_builder = if let Some(weight) = weight {
+                    cpu_builder.shares(weight.into_inner())
+                } else {
+                    cpu_builder
+                };
+
+                if let Some(max) = max {
+                    cpu_builder
+                        .quota(max.into_inner())
+                        .period(MICROSECONDS_PER_SECOND) // microseconds in a second
+                } else {
+                    cpu_builder
+                }
             } else {
-                builder
+                cpu_builder
             };
 
-            let builder = if let Some(max) = max {
-                builder.quota(max.into_inner()).period(MICROSECONDS_PER_SECOND) // microseconds in a second
-            } else {
-                builder
-            };
+            // cpuset controller
+            let cpu_builder =
+                if let Some(CpusetController { cpus, mems }) = cpuset {
+                    let cpu_builder = if let Some(cpus) = cpus {
+                        cpu_builder.cpus(cpus.into_inner())
+                    } else {
+                        cpu_builder
+                    };
 
-            builder.done()
+                    if let Some(mems) = mems {
+                        cpu_builder.mems(mems.into_inner())
+                    } else {
+                        cpu_builder
+                    }
+                } else {
+                    cpu_builder
+                };
+
+            let cpu = cpu_builder.build().expect("valid builder");
+            builder.cpu(cpu)
         } else {
             builder
         };
 
-        // cpuset controller
-        let builder = if let Some(CpusetController { cpus, mems }) = cpuset {
-            let builder = builder.cpu();
-
-            let builder = if let Some(cpus) = cpus {
-                builder.cpus(cpus.into_inner())
-            } else {
-                builder
-            };
-
-            let builder = if let Some(mems) = mems {
-                builder.mems(mems.into_inner())
-            } else {
-                builder
-            };
-
-            builder.done()
-        } else {
-            builder
+        let options = builder.build().expect("valid options");
+        let options = ControllerOpt {
+            resources: &options,
+            disable_oom_killer: false,
+            oom_score_adj: None,
+            freezer_state: None,
         };
 
-        let non_leaf = builder.build(hierarchy()).expect("valid cgroup");
+        let non_leaf = v2::manager::Manager::new(
+            DEFAULT_CGROUP_ROOT.into(),
+            cell_name.clone().into_inner(),
+        )
+        .expect("valid cgroup");
+
+        if let Err(e) = non_leaf.apply(&options) {
+            non_leaf.remove()?;
+            return Err(e);
+        }
 
         // Now, create the leaf cgroup where we can run processes.
         // NOTE: '_' is a disallowed character in CellName, so won't collide
-        name.push_str("/_");
-        let leaf =
-            CgroupBuilder::new(&name).build(hierarchy()).expect("valid cgroup");
+        let _leaf = v2::manager::Manager::new(
+            DEFAULT_CGROUP_ROOT.into(),
+            get_leaf_path(&cell_name),
+        )
+        .expect("valid cgroup");
 
-        Self { non_leaf, leaf }
+        Ok(Self { cell_name })
     }
 
-    pub fn add_task(&self, pid: Pid) -> cgroups_rs::error::Result<()> {
-        self.leaf.add_task_by_tgid((pid.as_raw() as u64).into())
+    pub fn add_task(&self, pid: Pid) -> anyhow::Result<()> {
+        let manager = v2::manager::Manager::new(
+            DEFAULT_CGROUP_ROOT.into(),
+            get_leaf_path(&self.cell_name),
+        )
+        .expect("valid cgroup");
+
+        let pid = nix_025::unistd::Pid::from_raw(pid.as_raw());
+        manager.add_task(pid)
     }
 
-    pub fn delete(&self) -> cgroups_rs::error::Result<()> {
-        self.leaf.delete()?;
-        self.non_leaf.delete()
+    pub fn delete(&self) -> anyhow::Result<()> {
+        let leaf = v2::manager::Manager::new(
+            DEFAULT_CGROUP_ROOT.into(),
+            get_leaf_path(&self.cell_name),
+        )
+        .expect("valid cgroup");
+
+        leaf.remove()?;
+
+        let non_leaf = v2::manager::Manager::new(
+            DEFAULT_CGROUP_ROOT.into(),
+            self.cell_name.clone().into_inner(),
+        )
+        .expect("valid cgroup");
+
+        non_leaf.remove()
     }
 
     pub fn v2(&self) -> bool {
-        self.non_leaf.v2()
+        // Auraed will assume the V2 cgroup hierarchy by default.
+        // For now, we do not change this, albeit in theory we could
+        // likely create backwards compatability for V1 hierarchy.
+        //
+        // For now, we simply... don't.
+        true
+    }
+
+    // TODO: use this
+    #[allow(unused)]
+    pub fn stats(&self) -> anyhow::Result<Stats> {
+        let non_leaf = v2::manager::Manager::new(
+            DEFAULT_CGROUP_ROOT.into(),
+            self.cell_name.clone().into_inner(),
+        )
+        .expect("valid cgroup");
+
+        non_leaf.stats()
     }
 
     pub fn exists(cell_name: &CellName) -> bool {
-        let mut path = PathBuf::from("/sys/fs/cgroup");
+        let mut path =
+            PathBuf::from_str(DEFAULT_CGROUP_ROOT).expect("valid path");
         path.push(cell_name.as_inner());
         path.exists()
     }
 }
 
-fn hierarchy() -> Box<dyn Hierarchy> {
-    // Auraed will assume the V2 cgroup hierarchy by default.
-    // For now, we do not change this, albeit in theory we could
-    // likely create backwards compatability for V1 hierarchy.
-    //
-    // For now, we simply... don't.
-    // hierarchies::auto() // Uncomment to auto detect Cgroup hierarchy
-    // hierarchies::V2
-    Box::new(hierarchies::V2::new())
+fn get_leaf_path(cell_name: &CellName) -> PathBuf {
+    // '_' is an invalid character in CellName, making it safe to use
+    cell_name.as_inner().join("_")
 }

--- a/auraed/src/cells/cell_service/cells/cgroups/error.rs
+++ b/auraed/src/cells/cell_service/cells/cgroups/error.rs
@@ -28,22 +28,19 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-pub use cgroup::Cgroup;
-pub use cpu::CpuController;
-pub use cpuset::CpusetController;
-pub use error::{CgroupsError, Result};
-pub use limit::Limit;
-pub use weight::Weight;
+use crate::cells::cell_service::cells::CellName;
+use thiserror::Error;
 
-mod cgroup;
-pub mod cpu;
-pub mod cpuset;
-mod error;
-mod limit;
-mod weight;
+pub type Result<T> = std::result::Result<T, CgroupsError>;
 
-#[derive(Debug, Clone)]
-pub struct CgroupSpec {
-    pub cpu: Option<CpuController>,
-    pub cpuset: Option<CpusetController>,
+#[derive(Error, Debug)]
+pub enum CgroupsError {
+    #[error("cgroup '{cell_name}' creation failed: {source}")]
+    CreateCgroup { cell_name: CellName, source: anyhow::Error },
+    #[error("cgroup '{cell_name}' failed to add task: {source}")]
+    AddTaskToCgroup { cell_name: CellName, source: anyhow::Error },
+    #[error("cgroup '{cell_name}' deletion failed: {source}")]
+    DeleteCgroup { cell_name: CellName, source: anyhow::Error },
+    #[error("cgroup '{cell_name}' failed to read stats: {source}")]
+    ReadStats { cell_name: CellName, source: anyhow::Error },
 }

--- a/auraed/src/cells/cell_service/cells/error.rs
+++ b/auraed/src/cells/cell_service/cells/error.rs
@@ -28,7 +28,7 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-use super::CellName;
+use super::{cgroups::CgroupsError, CellName};
 use std::io;
 use thiserror::Error;
 use tracing::error;
@@ -46,11 +46,11 @@ pub enum CellsError {
     #[error("cell '{cell_name}' could not be allocated: {source}")]
     FailedToAllocateCell { cell_name: CellName, source: io::Error },
     #[error("cell '{cell_name}' allocation was aborted: {source}")]
-    AbortedAllocateCell { cell_name: CellName, source: anyhow::Error },
+    AbortedAllocateCell { cell_name: CellName, source: CgroupsError },
     #[error("cell '{cell_name}' could not kill children: {source}")]
     FailedToKillCellChildren { cell_name: CellName, source: io::Error },
     #[error("cell '{cell_name}' could not be freed: {source}")]
-    FailedToFreeCell { cell_name: CellName, source: anyhow::Error },
+    FailedToFreeCell { cell_name: CellName, source: CgroupsError },
     #[error(
         "cgroup '{cell_name}' exists on host, but is not controlled by auraed"
     )]

--- a/auraed/src/cells/cell_service/cells/error.rs
+++ b/auraed/src/cells/cell_service/cells/error.rs
@@ -46,14 +46,11 @@ pub enum CellsError {
     #[error("cell '{cell_name}' could not be allocated: {source}")]
     FailedToAllocateCell { cell_name: CellName, source: io::Error },
     #[error("cell '{cell_name}' allocation was aborted: {source}")]
-    AbortedAllocateCell {
-        cell_name: CellName,
-        source: cgroups_rs::error::Error,
-    },
+    AbortedAllocateCell { cell_name: CellName, source: anyhow::Error },
     #[error("cell '{cell_name}' could not kill children: {source}")]
     FailedToKillCellChildren { cell_name: CellName, source: io::Error },
     #[error("cell '{cell_name}' could not be freed: {source}")]
-    FailedToFreeCell { cell_name: CellName, source: cgroups_rs::error::Error },
+    FailedToFreeCell { cell_name: CellName, source: anyhow::Error },
     #[error(
         "cgroup '{cell_name}' exists on host, but is not controlled by auraed"
     )]


### PR DESCRIPTION
This PR uses the libcgroups crate (part of youki repo) instead of cgroups-rs. We avoid issues with musl incompatibilities by not using the default features and only using the v2 feature which seems to compile without issue (I didn't look into which feature causes the issue).