### PR TITLE
Use correct license header when loading BPF programs

### DIFF
--- a/ebpf/src/probe-tracepoint-signal-signal-generate.rs
+++ b/ebpf/src/probe-tracepoint-signal-signal-generate.rs
@@ -28,10 +28,13 @@ use aya_bpf::macros::tracepoint;
 use aya_bpf::maps::PerfEventArray;
 use aya_bpf::programs::TracePointContext;
 
+#[link_section = "license"]
+#[used]
+pub static LICENSE: [u8; 13] = *b"Dual MIT/GPL\0";
+
 #[map(name = "SIGNALS")]
 static mut SIGNALS: PerfEventArray<Signal> =
     PerfEventArray::<Signal>::with_max_entries(1024, 0);
-
 
 // TODO (jeroensoeters): figure out how stable these offsets are and if we want
 //    to read from /sys/kernel/debug/tracing/events/signal/signal_generate/format
@@ -74,7 +77,6 @@ fn try_signals(ctx: TracePointContext) -> Result<u32, u32> {
     }
     Ok(0)
 }
-
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {


### PR DESCRIPTION
This PR ensures we send the correct license string to the kernel, as Aya was defaulting to "GPL".

Local `strace` output after adding this elf section:

```[pid 56599] bpf(BPF_PROG_LOAD, {prog_type=BPF_PROG_TYPE_TRACEPOINT, insn_cnt=31, insns=0x555556e28d00, license="Dual MIT/GPL", log_level=0, log_size=0, log_buf=NULL, kern_version=KERNEL_VERSION(6, 1, 9), prog_flags=0, prog_name="signals", prog_ifindex=0, expected_attach_type=BPF_CGROUP_INET_INGRESS, prog_btf_fd=0, func_info_rec_size=0, func_info=NULL, func_info_cnt=0, line_info_rec_size=0, line_info=NULL, line_info_cnt=0, attach_btf_id=0, attach_prog_fd=0, fd_array=NULL}, 144) = 12```