### PR TITLE
Make auraed "warn" about early development and change all versions to 0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "auraed"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "aurae-client",

--- a/aer/Cargo.toml
+++ b/aer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aer"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 authors = ["The Aurae Authors", "Kris Nóva <kris@nivenly.com>"]
 license = "Apache-2.0"

--- a/aurae-client/Cargo.toml
+++ b/aurae-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aurae-client"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 [dependencies]

--- a/aurae-proto/Cargo.toml
+++ b/aurae-proto/Cargo.toml
@@ -30,7 +30,7 @@
 
 [package]
 name = "aurae-proto"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 authors = ["The Aurae Authors", "Kris Nóva <kris@nivenly.com>"]
 license = "Apache-2.0"

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -30,7 +30,7 @@
 
 [package]
 name = "auraed"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 authors = ["The Aurae Authors", "Kris Nóva <kris@nivenly.com>"]
 license = "Apache-2.0"

--- a/auraed/src/init/mod.rs
+++ b/auraed/src/init/mod.rs
@@ -56,7 +56,31 @@ const BANNER: &str = "
     ┃  ██║  ██║╚██████╔╝██║  ██║██║  ██║███████╗ ┃
     ┃  ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝ ┃
     ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-         Distributed Systems Runtime Daemon\n";
+
+         Distributed Systems Runtime Daemon
+
+ ┌───────────────────────────────────────────────────┐
+ │  WARNING WARNING WARNING WARNING WARNING WARNING  │
+ │                                                   │
+ │ The Aurae Runtime Project is currently in a state │
+ │ of 'Early Active Development'. The current APIs   │
+ │ and features of the project should be considered  │
+ │ unstable. As the project matures the APIs and     │
+ │ features will stabilize.                          |
+ │                                                   │
+ │ As the project maintainers deem appropriate the   │
+ │ project will remove this warning.                 │
+ │                                                   │
+ │ At the time this banner is removed the project    │
+ │ will have documentation available in the main     │
+ │ repository on current API stability and backwards |
+ │ compatability.                                    │
+ │                                                   │
+ │          github.com/aurae-runtime/aurae           │
+ │                                                   │
+ │  WARNING WARNING WARNING WARNING WARNING WARNING  │
+ └───────────────────────────────────────────────────┘
+\n";
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum InitError {

--- a/auraescript/Cargo.toml
+++ b/auraescript/Cargo.toml
@@ -30,7 +30,7 @@
 
 [package]
 name = "auraescript"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 authors = ["The Aurae Authors", "Kris Nóva <kris@nivenly.com>"]
 license = "Apache-2.0"

--- a/ebpf/Cargo.toml
+++ b/ebpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebpf-probes"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 license = "Dual MIT/GPL"
 


### PR DESCRIPTION
Given the recent uptick in users/contributors it is probably wise to just make the main daemon self describe the current state of the project.

This PR introduces a hard-coded warning in the BANNER of the project that sets expectations with API and feature stability. 

We can remove this warning when we are confident that Aurae has stabilized a bit further.

Signed-off-by: Kris Nóva <kris@nivenly.com>