### PR TITLE
Re-enable cargo udeps and remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.0.0"
 dependencies = [
  "aer-macros",
  "anyhow",
- "clap 4.1.4",
+ "clap",
  "client",
  "futures-util",
  "proto",
@@ -141,11 +141,9 @@ dependencies = [
  "anyhow",
  "aurae-ebpf-shared",
  "aya",
- "aya-log",
  "backoff",
  "bytes",
- "cgroups-rs",
- "clap 4.1.4",
+ "clap",
  "client",
  "clone3",
  "fancy-regex",
@@ -156,13 +154,11 @@ dependencies = [
  "libc",
  "libcgroups 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libcontainer",
- "liboci-cli",
  "log",
  "multi_log",
  "netlink-packet-route",
  "nix 0.25.1",
  "oci-spec 0.5.8",
- "ocipkg",
  "procfs",
  "proto",
  "rtnetlink",
@@ -283,30 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aya-log"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe523bb45d7b2916b73f781580d308545fe843712c8154728168af1e7ec26b66"
-dependencies = [
- "aya",
- "aya-log-common",
- "bytes",
- "log",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "aya-log-common"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0213297ff4b3d9156ed6c479d34a6eeb27b39dab5b88cd438cfd137ad63a945c"
-dependencies = [
- "aya",
- "num_enum",
-]
-
-[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,12 +291,6 @@ dependencies = [
  "rand",
  "tokio",
 ]
-
-[[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
@@ -440,19 +406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cgroups-rs"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5761f3a351b92e0e02a31ca418190bb323edb0d4fce0109b6dba673dc3fdc1"
-dependencies = [
- "libc",
- "log",
- "nix 0.25.1",
- "regex",
- "thiserror",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,45 +423,17 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
-dependencies = [
- "bitflags",
- "clap_derive 3.2.18",
- "clap_lex 0.2.4",
- "indexmap",
- "once_cell",
- "strsim",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
- "clap_derive 4.1.0",
- "clap_lex 0.3.1",
+ "clap_derive",
+ "clap_lex",
  "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -522,15 +447,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -962,26 +878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dprint-swc-ext"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,18 +949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall",
- "windows-sys",
 ]
 
 [[package]]
@@ -1660,15 +1544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "liboci-cli"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f707717247a34421d9c8aa0448452cde6d5d2ac455257f5fc4d53ec607264a4"
-dependencies = [
- "clap 3.2.23",
-]
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,33 +1892,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "ocipkg"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60cf01280832705a4e4c4d046d9e67a54b900297c69191457a8fc6d198ddefa2"
-dependencies = [
- "base16ct",
- "base64 0.13.1",
- "chrono",
- "directories",
- "flate2",
- "lazy_static",
- "log",
- "oci-spec 0.5.8",
- "regex",
- "serde",
- "serde_json",
- "sha2",
- "tar",
- "thiserror",
- "toml",
- "ureq",
- "url",
- "uuid",
- "walkdir",
 ]
 
 [[package]]
@@ -2447,17 +2295,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,17 +2580,6 @@ name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -3303,17 +3129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,12 +3166,6 @@ checksum = "7fd5828de7deaa782e1dd713006ae96b3bee32d3279b79eb67ecf8072c059bcf"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -3820,24 +3629,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "ureq"
-version = "2.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
-dependencies = [
- "base64 0.13.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "serde",
- "serde_json",
- "url",
- "webpki",
- "webpki-roots",
-]
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4039,15 +3830,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
 name = "which"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,15 +3944,6 @@ dependencies = [
  "signature",
  "spki",
  "thiserror",
-]
-
-[[package]]
-name = "xattr"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ headers-write: ## Fix any problematic files blindly.
 
 .PHONY: check-deps
 check-deps: musl $(GEN_TS) $(GEN_RS) ## Check if there are any unused dependencies in Cargo.toml
-#	cargo +nightly udeps --target $(uname_m)-unknown-linux-musl --package auraed
-#	cargo +nightly udeps --package auraescript
-#	cargo +nightly udeps --package client
-#	cargo +nightly udeps --package aer
+	cargo +nightly udeps --target $(uname_m)-unknown-linux-musl --package auraed
+	cargo +nightly udeps --package auraescript
+	cargo +nightly udeps --package client
+	cargo +nightly udeps --package aer

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -39,15 +39,17 @@ license = "Apache-2.0"
 name = "auraed"
 path = "src/bin/main.rs"
 
+[package.metadata.cargo-udeps.ignore]
+normal = []
+development = ["multi_log", "simplelog"]
+
 [dependencies]
 anyhow = { workspace = true }
 client = { workspace = true }
 aurae-ebpf-shared = { path = "../ebpf-shared" }
 aya = { version = ">=0.11", features=["async_tokio"] }
-aya-log = "0.1"
 backoff = { version = "0.4.0", features = ["tokio"] }
 bytes = "1.2.1"
-cgroups-rs = "0.3.0"
 clap = { workspace = true }
 clone3 = "0.2.3"
 fancy-regex = { workspace = true }
@@ -58,19 +60,15 @@ libc = "0.2" # TODO: Nix comes with libc, can we rely on that?
 lazy_static = { workspace = true }
 libcgroups = { version = "0.0.4", default-features = false, features = ["v2"] }
 libcontainer = { git = "https://github.com/krisnova/youki", branch = "musl-libcontainer", features = ["v2"], default-features = false }
-liboci-cli = "0.0.4"
 log = "0.4.17"
-multi_log = "0.1.2"
 netlink-packet-route = "0.13.0" # Used for netlink_packet_route::rtnl::address::nlas definition
 nix = { workspace = true, features = ["sched"] }
-ocipkg = "0.2.8"
 oci-spec = "0.5" # upgrade to 0.6 blocked by libcgroups as of v0.0.4
 procfs = "0.14.2"
 proto = { workspace = true }
 rtnetlink = "0.11.0"
 serde_json.workspace = true
 serde.workspace = true
-simplelog = "0.12.0"
 syslog-tracing = "0.1.0"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "net", "process", "rt-multi-thread", "signal", "sync"] }
@@ -86,5 +84,7 @@ validation_macros = { path = "../crates/validation/macros" }
 walkdir = "2"
 
 [dev-dependencies]
+multi_log = "0.1.2"
+simplelog = "0.12.0"
 simple_test_case = "1.1.0"
 test-helpers = { workspace = true }

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -39,10 +39,6 @@ license = "Apache-2.0"
 name = "auraed"
 path = "src/bin/main.rs"
 
-[package.metadata.cargo-udeps.ignore]
-normal = []
-development = ["multi_log", "simplelog"]
-
 [dependencies]
 anyhow = { workspace = true }
 client = { workspace = true }


### PR DESCRIPTION
I moved `simplelog` and `multi-log` crates to `dev-dependencies` because they were only used in unittests. As for running udeps as nightly and building for musl, ~it works on my machine :shrug:. We will see when the gh actions run~ the gh actions passed, maybe it was just a buggy version of the nightly musl target or the cargo-udeps crate.

Closes #306 