### PR TITLE
typo in the ubuntu install instructions

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -25,7 +25,7 @@ commands provided below.
 ```bash
 sudo apt-get install -y protobuf-compiler; # Protocol Buffer Compiler
 sudo apt-get install -y musl-tools; # musl libc
-sudo apt-get install -y build-essentials; # gcc compiler
+sudo apt-get install -y build-essential; # gcc compiler
 ```
 
 ##### Arch


### PR DESCRIPTION
the required package for ubuntu is not `build-essentials` but `build-essential`.

here is the ubuntu package registry for reference: [https://packages.ubuntu.com/focal/build-essential](https://packages.ubuntu.com/focal/build-essential)