### PR TITLE
docs: include build dependencies for Fedora

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -28,6 +28,14 @@ sudo apt-get install -y musl-tools; # musl libc
 sudo apt-get install -y build-essential; # gcc compiler
 ```
 
+##### Fedora
+
+```bash
+sudo dnf install -y protobuf-compiler; # Protocol Buffer Compiler
+sudo dnf install -y musl-gcc; # musl libc
+sudo dnf install -y '@Development Tools'; # gcc compiler
+```
+
 ##### Arch
 
 ```bash


### PR DESCRIPTION
This PR includes build dependency instructions for Fedora based on the Ubuntu
ones, as some packages are named differently (namely `musl-tools`, as it is
provided by `musl-gcc`).

Hope this helps other Fedora users get going :)
