### PR TITLE
Makefile mark config target NOTPARALLEL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,11 +322,11 @@ spawn: ## Spawn the current auraed binary and start it in a container
 	./hack/spawn
 
 .PHONY: busybox
-busybox: ## Creat a "busybox" OCI bundle in target
+busybox: ## Create a "busybox" OCI bundle in target
 	./hack/oci-busybox
 
 .PHONY: alpine
-alpine: ## Creat an "alpine" OCI bundle in target
+alpine: ## Create an "alpine" OCI bundle in target
 	./hack/oci-alpine
 
 #------------------------------------------------------------------------------#

--- a/Makefile
+++ b/Makefile
@@ -90,11 +90,13 @@ prcheck: build lint test-all docs docs-lint ## Meant to mimic the GHA checks (in
 # Setup Commands
 
 .PHONY: pki
-pki: certs ## Alias for certs
+pki: install-certs ## Alias for install-certs
 .PHONY: certs
 certs: clean-certs ## Generate x509 mTLS certs in /pki directory
 	mkdir -p pki
 	./hack/certgen
+.PHONY: install-certs
+install-certs: certs ## Install certs in /etc/aurae
 ifeq ($(uid), 0)
 	mkdir -p /etc/aurae/pki
 	cp -v pki/* /etc/aurae/pki
@@ -105,7 +107,7 @@ endif
 	@echo "Install PKI Auth Material [/etc/aurae]"
 
 .PHONY: config
-config: ## Set up default config
+config: certs ## Set up default config
 	mkdir -p $(HOME)/.aurae
 	cp -v auraescript/default.config.toml $(HOME)/.aurae/config
 	sed -i 's|~|$(HOME)|g' $(HOME)/.aurae/config


### PR DESCRIPTION
`config` target depends on `certs` target being already completed,
when running make with -j2, both target runs concurrently which
leads to errors in `config`. Marking `config` as NOTPARALLEL
prevent concurrency when `config` is running.