### PR TITLE
Make ebpf-shared::Signal pid field a `u32`

### DIFF
--- a/ebpf-shared/src/lib.rs
+++ b/ebpf-shared/src/lib.rs
@@ -5,5 +5,5 @@
 pub struct Signal {
     pub cgroup_id: u64,
     pub signum: i32,
-    pub pid: i32,
+    pub pid: u32,
 }


### PR DESCRIPTION
It is explicitly a u32 in `/ebpf` and u32 makes more sense for PIDs