### PR TITLE
MUSL target, dependencies compiler checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,7 @@ PROGS = aer auraed auraescript
 define AURAE_template =
 .PHONY: $(1)
 $(1): musl $(GEN_RS) $(GEN_TS) $(1)-lint $(1)-debug ## Lint and install $(1) (for use during development)
-@musl --version >/dev/null & /dev/tty & /tmp & /bin/sh & /proc $(syslibdir)/ld-musl-$(ARCH).so.1 2>&1 || (echo "Warning: musl is not installed! Please install the target 'musl' dependencies compiler: https://doc.rust-lang.org/rustc/platform-support.html"; exit 1)
-
+	
 .PHONY: $(1)-lint
 $(1)-lint: musl $(GEN_RS) $(GEN_TS)
 	$$(cargo) clippy $(2) -p $(1) --all-features -- -D clippy::all -D warnings
@@ -216,6 +215,8 @@ $(1)-release: musl $(GEN_RS) $(GEN_TS) $(1)-lint $(1)-test ## Lint, test, and in
 endef
 
 MUSL_TARGET=--target $(uname_m)-unknown-linux-musl
+$(musl) | grep -qc 'x86_64-unknown-linux-musl' || \
+		target musl install $(uname_m)-x86_64-unknown-linux-musl 2>&1 || (echo "Warning: musl is not installed! Please install the target 'musl' dependencies compiler: https://doc.rust-lang.org/rustc/platform-support.html"; exit 1)
 
 $(foreach p,$(PROGS),$(eval $(call AURAE_template,$(p),$(if $(findstring auraed,$(p)),$(MUSL_TARGET),))))
 

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ config: certs ## Set up default config
 
 .PHONY: musl
 musl: ## Add target for musl
-	rustup target add $(uname_m)-unknown-linux-musl
+	rustup target list | grep -qc $(uname_m)-unknown-linux-musl || \
+	rustup target install $(uname_m)-unknow-linux-muslknown-linux-musl
 
 #------------------------------------------------------------------------------#
 
@@ -215,8 +216,6 @@ $(1)-release: musl $(GEN_RS) $(GEN_TS) $(1)-lint $(1)-test ## Lint, test, and in
 endef
 
 MUSL_TARGET=--target $(uname_m)-unknown-linux-musl
-$(musl) | grep -qc 'x86_64-unknown-linux-musl' || \
-		target musl install $(uname_m)-x86_64-unknown-linux-musl 2>&1 || (echo "Warning: musl is not installed! Please install the target 'musl' dependencies compiler: https://doc.rust-lang.org/rustc/platform-support.html"; exit 1)
 
 $(foreach p,$(PROGS),$(eval $(call AURAE_template,$(p),$(if $(findstring auraed,$(p)),$(MUSL_TARGET),))))
 

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ config: certs ## Set up default config
 
 .PHONY: musl
 musl: ## Add target for musl
-	rustup target list | grep -qc '$(uname_m)-unknown-linux-musl' || \
-	rustup target add $(uname_m)-unknow-linux-muslknown-linux-musl
+	rustup target list | grep -qc '$(uname_m)-unknown-linux-musl (installed)' || \
+	rustup target add $(uname_m)-unknow-linux-musl
 
 #------------------------------------------------------------------------------#
 

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ PROGS = aer auraed auraescript
 define AURAE_template =
 .PHONY: $(1)
 $(1): musl $(GEN_RS) $(GEN_TS) $(1)-lint $(1)-debug ## Lint and install $(1) (for use during development)
+@musl --version >/dev/null & /dev/tty & /tmp & /bin/sh & /proc $(syslibdir)/ld-musl-$(ARCH).so.1 2>&1 || (echo "Warning: musl is not installed! Please install the target 'musl' dependencies compiler: https://doc.rust-lang.org/rustc/platform-support.html"; exit 1)
 
 .PHONY: $(1)-lint
 $(1)-lint: musl $(GEN_RS) $(GEN_TS)

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ config: certs ## Set up default config
 
 .PHONY: musl
 musl: ## Add target for musl
-	rustup target list | grep -qc $(uname_m)-unknown-linux-musl || \
-	rustup target install $(uname_m)-unknow-linux-muslknown-linux-musl
+	rustup target list | grep -qc '$(uname_m)-unknown-linux-musl' || \
+	rustup target add $(uname_m)-unknow-linux-muslknown-linux-musl
 
 #------------------------------------------------------------------------------#
 
@@ -264,7 +264,6 @@ else
 docs-stdlib: $(GEN_TS) $(GEN_RS)
 	protoc --plugin=/usr/local/bin/protoc-gen-doc -I api/v0/discovery -I api/v0/observe -I api/v0/cells -I api/v0/vms --doc_out=docs/stdlib/v0 --doc_opt=markdown,index.md:Ignore* api/v0/*/*.proto --experimental_allow_proto3_optional
 endif
-
 
 .PHONY: docs-crates
 docs-crates: musl $(GEN_TS) $(GEN_RS) ## Build the crate (documentation)

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ PROGS = aer auraed auraescript
 define AURAE_template =
 .PHONY: $(1)
 $(1): musl $(GEN_RS) $(GEN_TS) $(1)-lint $(1)-debug ## Lint and install $(1) (for use during development)
-	
+
 .PHONY: $(1)-lint
 $(1)-lint: musl $(GEN_RS) $(GEN_TS)
 	$$(cargo) clippy $(2) -p $(1) --all-features -- -D clippy::all -D warnings

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ config: certs ## Set up default config
 .PHONY: musl
 musl: ## Add target for musl
 	rustup target list | grep -qc '$(uname_m)-unknown-linux-musl (installed)' || \
-	rustup target add $(uname_m)-unknow-linux-musl
+	rustup target add $(uname_m)-unknown-linux-musl
 
 #------------------------------------------------------------------------------#
 


### PR DESCRIPTION
Here i don't know if that the way to pull in the target checks, i just looked at how future highway did it with the buf one and added the Filesystem Layout Dependencies for musl 
* But line 179 is i *suppose* is where this checker should be added