### PR TITLE
Cargo deny check licenses

### DIFF
--- a/.github/workflows/206-deny-check-aurae-builder-make-check-deny.yml
+++ b/.github/workflows/206-deny-check-aurae-builder-make-check-deny.yml
@@ -27,65 +27,51 @@
 #   limitations under the License.                                             #
 #                                                                              #
 # ---------------------------------------------------------------------------- #
-#
-# The primary Aurae test container, used to cache and support the GitHub
-# builds.
-#
-# This container image is NOT intended to run Aurae in production.
-# For internal builds of auraed use Dockerfile.build
-#
-# syntax = docker/dockerfile:1.4
-FROM rust:1-slim-bullseye as main
-LABEL org.opencontainers.image.source https://github.com/aurae-runtime/aurae
 
-## Define ARGs
-ARG CACHE_VERSION=v0
-ARG BUF_VERSION=1.11.0
-ARG VALE_VERSION=2.21.3
-ARG PROTOC_VERSION=1.5.1
+# https://github.com/marketplace/actions/cargo-deny
 
-## Install packages
-RUN  apt-get update && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    make \
-    musl-tools \
-    protobuf-compiler \
-    git \
-    python3-pip \
-    libssl-dev \
-    openssl \
-    pkg-config
-RUN rm -rf /var/lib/apt/lists/*
+name: "Check deny (206) [aurae-builder:tester-latest]"
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
 
-## Setup Rust
-RUN rustup component add clippy
-RUN rustup +nightly target add x86_64-unknown-linux-musl
-RUN rustup target add x86_64-unknown-linux-musl
-
-## Setup protoc-gen-doc
-RUN curl  -O -J -L https://github.com/pseudomuto/protoc-gen-doc/releases/download/v${PROTOC_VERSION}/protoc-gen-doc_${PROTOC_VERSION}_linux_amd64.tar.gz && \
-    tar -xzf protoc-gen-doc_${PROTOC_VERSION}_linux_amd64.tar.gz && \
-    chmod +x protoc-gen-doc && \
-    mv protoc-gen-doc /usr/local/bin/protoc-gen-doc && \
-    rm protoc-gen-doc_${PROTOC_VERSION}_linux_amd64.tar.gz
-
-## Setup Buf
-RUN curl -sSL \
-    "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-$(uname -s)-$(uname -m)" \
-    -o "/usr/local/bin/buf" && \
-    chmod +x "/usr/local/bin/buf"
-
-## Setup Vale
-RUN curl -sSl -J -L "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" \
-    -o vale.tar.gz && \
-    tar -xvzf vale.tar.gz -C bin && \
-    mv bin/vale /usr/local/bin/vale && \
-    rm vale.tar.gz
-
-
-## Setup cargo-udeps
-RUN cargo install cargo-udeps
-RUN cargo install cargo-deny
-
-WORKDIR /aurae
+permissions:
+  contents: read
+  packages: write
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  build-container:
+    uses: ./.github/workflows/200-aurae-builder-image-docker-build-tester.yml
+  check-deny:
+    name: Check deny
+    runs-on: ubuntu-latest
+    needs: build-container
+    container:
+      image: ghcr.io/${{ github.repository }}/aurae-builder:tester-latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      matrix:
+        # - advisories
+        - bans licenses sources
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        id: cargo-cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: 200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check ${{ matrix.checks }}

--- a/.github/workflows/206-deny-check-aurae-builder-make-check-deny.yml
+++ b/.github/workflows/206-deny-check-aurae-builder-make-check-deny.yml
@@ -56,8 +56,9 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix:
-        # - advisories
-        - bans licenses sources
+        checks:
+#          - advisories
+          - bans licenses sources
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:

--- a/.github/workflows/206-deny-check-aurae-builder.yml
+++ b/.github/workflows/206-deny-check-aurae-builder.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         checks:
-#          - advisories
+          - advisories
           - bans licenses sources
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: ${{ matrix.checks == 'advisories' }}

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,11 @@ headers-write: ## Fix any problematic files blindly.
 
 .PHONY: check-deps
 check-deps: musl $(GEN_TS) $(GEN_RS) ## Check if there are any unused dependencies in Cargo.toml
-	cargo +nightly udeps --target $(uname_m)-unknown-linux-musl --package auraed
-	cargo +nightly udeps --package auraescript
-	cargo +nightly udeps --package client
-	cargo +nightly udeps --package aer
+	$(cargo) +nightly udeps --target $(uname_m)-unknown-linux-musl --package auraed
+	$(cargo) +nightly udeps --package auraescript
+	$(cargo) +nightly udeps --package client
+	$(cargo) +nightly udeps --package aer
+
+.PHONY: check-deny
+check-deny: musl $(GEN_TS) $(GEN_RS) ## Run cargo-deny
+	$(cargo) deny check

--- a/deny.toml
+++ b/deny.toml
@@ -102,9 +102,15 @@ unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
     "Apache-2.0",
-    #"Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "LicenseRef-ring",
+    "LicenseRef-webpki",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-DFS-2016",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
@@ -158,6 +164,36 @@ exceptions = [
     # Each entry is a crate relative path, and the (opaque) hash of its contents
     #{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
+
+[[licenses.clarify]]
+name = "libcgroups"
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x8767455a }
+]
+
+[[licenses.clarify]]
+name = "libcontainer"
+expression = "Apache-2.0"
+license-files = [
+    { path = "LICENSE", hash = 0x8767455a }
+]
+
+# https://github.com/briansmith/ring/blob/main/LICENSE (ISC AND MIT AND OpenSSL)
+[[licenses.clarify]]
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+# https://github.com/briansmith/webpki/blob/main/LICENSE (ISC-style)
+[[licenses.clarify]]
+name = "webpki"
+expression = "LicenseRef-webpki"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c }
+]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only

--- a/ebpf-shared/Cargo.toml
+++ b/ebpf-shared/Cargo.toml
@@ -3,6 +3,8 @@ name = "aurae-ebpf-shared"
 version = "0.0.0"
 publish = false
 edition = "2021"
+authors = ["The Aurae Authors", "Kris Nóva <kris@nivenly.com>"]
+license = "Apache-2.0"
 
 [features]
 default = []


### PR DESCRIPTION
With these changes we will be passing the cargo-deny checks for licenses.

I left advisories off of CI for now. We fail the check.

Our ebpf-shared crate did not have a license. I set it to Apache 2.0, like auared. Should it be MIT since the ebpf crate is Dual MIT/GPL?