### PR TITLE
Don't use /proc/self/exe in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,19 +198,19 @@ $(1)-lint: musl $(GEN_RS) $(GEN_TS)
 	$$(cargo) clippy $(2) -p $(1) --all-features -- -D clippy::all -D warnings
 
 .PHONY: $(1)-test
-$(1)-test: musl $(GEN_RS) $(GEN_TS)
+$(1)-test: musl $(GEN_RS) $(GEN_TS) $(1)
 	$(cargo) test $(2) -p $(1)
 
 .PHONY: $(1)-test-all
-$(1)-test-all: musl $(GEN_RS) $(GEN_TS)
+$(1)-test-all: musl $(GEN_RS) $(GEN_TS) $(1)
 	$(root_cargo) test $(2) -p $(1) -- --include-ignored
 
 .PHONY: $(1)-test-integration
-$(1)-test-integration: musl $(GEN_RS) $(GEN_TS)
+$(1)-test-integration: musl $(GEN_RS) $(GEN_TS) $(1)
 	$(root_cargo) test $(2) -p $(1) --test '*' -- --include-ignored
 
 .PHONY: $(1)-test-watch
-$(1)-test-watch: musl $(GEN_RS) $(GEN_TS) # Use cargo-watch to continuously run a test (e.g. make $(1)-test-watch name=path::to::test)
+$(1)-test-watch: musl $(GEN_RS) $(GEN_TS) $(1) # Use cargo-watch to continuously run a test (e.g. make $(1)-test-watch name=path::to::test)
 	$(root_cargo) watch -- $(cargo) test $(2) -p $(1) $(name) -- --include-ignored --nocapture
 
 .PHONY: $(1)-build

--- a/auraed/src/bin/main.rs
+++ b/auraed/src/bin/main.rs
@@ -159,6 +159,7 @@ async fn handle_default(options: AuraedOptions) -> i32 {
     } = options;
 
     let AuraedRuntime {
+        auraed: default_auraed,
         ca_crt: default_ca_crt,
         server_crt: default_server_crt,
         server_key: default_server_key,
@@ -167,6 +168,7 @@ async fn handle_default(options: AuraedOptions) -> i32 {
     } = AuraedRuntime::default();
 
     let runtime = AuraedRuntime {
+        auraed: default_auraed,
         ca_crt: ca_crt.map(PathBuf::from).unwrap_or(default_ca_crt),
         server_crt: server_crt.map(PathBuf::from).unwrap_or(default_server_crt),
         server_key: server_key.map(PathBuf::from).unwrap_or(default_server_key),

--- a/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
+++ b/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
@@ -44,8 +44,6 @@ use std::{
 };
 use tracing::{error, info, trace};
 
-const PROC_SELF_EXE: &str = "/proc/self/exe";
-
 #[derive(Debug)]
 pub struct NestedAuraed {
     process: procfs::process::Process,
@@ -73,12 +71,7 @@ impl NestedAuraed {
             uuid::Uuid::new_v4(),
         );
 
-        let mut command = if let Some(path) = &auraed_runtime.auraed {
-            Command::new(path)
-        } else {
-            // Here we read /proc/self/exe which will be a symbolic link to our binary.
-            Command::new(std::fs::read_link(PROC_SELF_EXE)?)
-        };
+        let mut command = Command::new(&auraed_runtime.auraed);
 
         let _ = command.current_dir("/").args([
             "--socket",

--- a/auraed/tests/common/mod.rs
+++ b/auraed/tests/common/mod.rs
@@ -66,7 +66,7 @@ async fn run_auraed() -> Client {
 
     let _ = tokio::spawn(async move {
         let mut runtime = AuraedRuntime::default();
-        runtime.auraed = Some("auraed".into());
+        runtime.auraed = "auraed".into();
 
         auraed::run(runtime, Some(socket), false, false).await.unwrap()
     });

--- a/auraed/tests/common/mod.rs
+++ b/auraed/tests/common/mod.rs
@@ -48,7 +48,6 @@ where
 }
 
 async fn run_auraed() -> Client {
-    let runtime = AuraedRuntime::default();
     let socket = std::env::temp_dir()
         .join(format!("{}.socket", uuid::Uuid::new_v4()))
         .to_string_lossy()
@@ -66,6 +65,9 @@ async fn run_auraed() -> Client {
     };
 
     let _ = tokio::spawn(async move {
+        let mut runtime = AuraedRuntime::default();
+        runtime.auraed = Some("auraed".into());
+
         auraed::run(runtime, Some(socket), false, false).await.unwrap()
     });
 


### PR DESCRIPTION
Test binaries do not include the code in main.rs, and therefore, do not have command arg parsing. So, when we use `/proc/self/exe` to launch a nested auraed in tests, the command args are not parsed and the nested auraed runs, but doesn't do anything.