### PR TITLE
Nested auraed inherit config through command args

### DIFF
--- a/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
+++ b/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
@@ -66,27 +66,39 @@ impl NestedAuraed {
         // TODO: handle expect
         let mut client_config =
             AuraeConfig::try_default().expect("file based config");
-        client_config.system.socket = format!(
+        let client_socket = format!(
             "{}/aurae-{}.sock",
             auraed_runtime.runtime_dir.to_string_lossy(),
             uuid::Uuid::new_v4(),
         );
 
+        client_config.system.socket = client_socket.clone();
+
         let auraed_path: PathBuf =
             auraed_runtime.auraed.clone().try_into().expect("path to auraed");
-        let mut command = Command::new(auraed_path);
 
-        let _ = command.current_dir("/").args([
+        let mut command = Command::new(auraed_path);
+        let _ = command.args([
             "--socket",
-            &client_config.system.socket,
+            &client_socket,
             "--nested", // NOTE: for now, the nested flag only signals for the code in the init module to not trigger (i.e., don't run the pid 1 code, run the non pid 1 code)
+            "--server-crt",
+            &auraed_runtime.server_crt.to_string_lossy(),
+            "--server-key",
+            &auraed_runtime.server_key.to_string_lossy(),
+            "--ca-crt",
+            &auraed_runtime.ca_crt.to_string_lossy(),
+            "--runtime-dir",
+            &auraed_runtime.runtime_dir.to_string_lossy(),
+            "--library-dir",
+            &auraed_runtime.library_dir.to_string_lossy(),
         ]);
 
         // We have a concern that the "command" API make change/break in the future and this
         // test is intended to help safeguard against that!
         // We check that the command we kept has the expected number of args following the call
         // to command.args, whose return value we ignored above.
-        assert_eq!(command.get_args().len(), 3);
+        assert_eq!(command.get_args().len(), 13);
 
         // *****************************************************************
         // ██████╗██╗      ██████╗ ███╗   ██╗███████╗██████╗

--- a/client/src/config/mod.rs
+++ b/client/src/config/mod.rs
@@ -81,7 +81,7 @@ impl AuraeConfig {
                     return Ok(config);
                 }
                 Err(e) => {
-                    println!("warning: failed to parse config at {path}: {e}");
+                    eprintln!("warning: failed to parse config at {path}: {e}");
                     continue;
                 }
             }


### PR DESCRIPTION
In order for relative path in options to work, we also remove current_dir("/") for the forked client

Make ClientConfig output warnings on stderr