### PR TITLE
Remove TLS between daemon and cells

### DIFF
--- a/auraed/src/cells/cell_service/cell_service.rs
+++ b/auraed/src/cells/cell_service/cell_service.rs
@@ -64,8 +64,8 @@ macro_rules! do_in_cell {
     ($self:ident, $cell_name:ident, $function:ident, $request:ident) => {{
         let mut cells = $self.cells.lock().await;
 
-        let client_config = cells
-            .get(&$cell_name, |cell| cell.client_config())
+        let client_system_config = cells
+            .get(&$cell_name, |cell| cell.client_system_config())
             .map_err(CellsServiceError::CellsError)?;
 
         let mut retry_strategy = backoff::ExponentialBackoffBuilder::new()
@@ -77,7 +77,7 @@ macro_rules! do_in_cell {
             .build();
 
         let client = loop {
-            match Client::new(client_config.clone()).await {
+            match Client::new_no_auth(client_system_config.clone()).await {
                 Ok(client) => break Ok(client),
                 e @ Err(ClientError::ConnectionError(_)) => {
                     trace!("aurae client failed to connect: {e:?}");

--- a/auraed/src/cells/cell_service/cell_service.rs
+++ b/auraed/src/cells/cell_service/cell_service.rs
@@ -64,8 +64,8 @@ macro_rules! do_in_cell {
     ($self:ident, $cell_name:ident, $function:ident, $request:ident) => {{
         let mut cells = $self.cells.lock().await;
 
-        let client_system_config = cells
-            .get(&$cell_name, |cell| cell.client_system_config())
+        let client_socket = cells
+            .get(&$cell_name, |cell| cell.client_socket())
             .map_err(CellsServiceError::CellsError)?;
 
         let mut retry_strategy = backoff::ExponentialBackoffBuilder::new()
@@ -77,7 +77,7 @@ macro_rules! do_in_cell {
             .build();
 
         let client = loop {
-            match Client::new_no_auth(client_system_config.clone()).await {
+            match Client::new_no_tls(client_socket.clone()).await {
                 Ok(client) => break Ok(client),
                 e @ Err(ClientError::ConnectionError(_)) => {
                     trace!("aurae client failed to connect: {e:?}");

--- a/auraed/src/cells/cell_service/cells/cell.rs
+++ b/auraed/src/cells/cell_service/cells/cell.rs
@@ -32,7 +32,6 @@ use super::{
     cgroups::Cgroup, nested_auraed::NestedAuraed, CellName, CellSpec, Cells,
     CellsCache, CellsError, Result,
 };
-use client::SystemConfig;
 use tracing::info;
 
 // TODO https://github.com/aurae-runtime/aurae/issues/199 &&
@@ -169,14 +168,14 @@ impl Cell {
 
     // NOTE: Having this function return the Client means we need to make it async,
     // or we need to make [Client::new] not async.
-    pub fn client_system_config(&self) -> Result<SystemConfig> {
+    pub fn client_socket(&self) -> Result<String> {
         let CellState::Allocated { nested_auraed, .. } = &self.state else {
             return Err(CellsError::CellNotAllocated {
                 cell_name: self.cell_name.clone(),
             })
         };
 
-        Ok(nested_auraed.client_system_config.clone())
+        Ok(nested_auraed.client_socket.clone())
     }
 
     /// Returns the [CellName] of the [Cell]

--- a/auraed/src/cells/cell_service/cells/cell.rs
+++ b/auraed/src/cells/cell_service/cells/cell.rs
@@ -32,7 +32,7 @@ use super::{
     cgroups::Cgroup, nested_auraed::NestedAuraed, CellName, CellSpec, Cells,
     CellsCache, CellsError, Result,
 };
-use client::AuraeConfig;
+use client::SystemConfig;
 use tracing::info;
 
 // TODO https://github.com/aurae-runtime/aurae/issues/199 &&
@@ -169,14 +169,14 @@ impl Cell {
 
     // NOTE: Having this function return the Client means we need to make it async,
     // or we need to make [Client::new] not async.
-    pub fn client_config(&self) -> Result<AuraeConfig> {
+    pub fn client_system_config(&self) -> Result<SystemConfig> {
         let CellState::Allocated { nested_auraed, .. } = &self.state else {
             return Err(CellsError::CellNotAllocated {
                 cell_name: self.cell_name.clone(),
             })
         };
 
-        Ok(nested_auraed.client_config.clone())
+        Ok(nested_auraed.client_system_config.clone())
     }
 
     /// Returns the [CellName] of the [Cell]

--- a/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
+++ b/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
@@ -30,7 +30,7 @@
 
 use super::isolation_controls::{Isolation, IsolationControls};
 use crate::AURAED_RUNTIME;
-use client::AuraeConfig;
+use client::SystemConfig;
 use clone3::Flags;
 use nix::{
     libc::SIGCHLD,
@@ -52,7 +52,7 @@ pub struct NestedAuraed {
     pidfd: i32,
     #[allow(unused)]
     iso_ctl: IsolationControls,
-    pub client_config: AuraeConfig,
+    pub client_system_config: SystemConfig,
 }
 
 impl NestedAuraed {
@@ -63,16 +63,11 @@ impl NestedAuraed {
 
         let auraed_runtime = AURAED_RUNTIME.get().expect("runtime");
 
-        // TODO: handle expect
-        let mut client_config =
-            AuraeConfig::try_default().expect("file based config");
-        let client_socket = format!(
+        let socket = format!(
             "{}/aurae-{}.sock",
             auraed_runtime.runtime_dir.to_string_lossy(),
             uuid::Uuid::new_v4(),
         );
-
-        client_config.system.socket = client_socket.clone();
 
         let auraed_path: PathBuf =
             auraed_runtime.auraed.clone().try_into().expect("path to auraed");
@@ -80,7 +75,7 @@ impl NestedAuraed {
         let mut command = Command::new(auraed_path);
         let _ = command.args([
             "--socket",
-            &client_socket,
+            &socket,
             "--nested", // NOTE: for now, the nested flag only signals for the code in the init module to not trigger (i.e., don't run the pid 1 code, run the non pid 1 code)
             "--server-crt",
             &auraed_runtime.server_crt.to_string_lossy(),
@@ -179,7 +174,10 @@ impl NestedAuraed {
                 let process = procfs::process::Process::new(pid)
                     .map_err(|e| io::Error::new(ErrorKind::Other, e))?;
 
-                Ok(Self { process, pidfd, iso_ctl, client_config })
+                let client_system_config = SystemConfig {
+                    socket
+                };
+                Ok(Self { process, pidfd, iso_ctl, client_system_config })
             }
         }
     }

--- a/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
+++ b/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
@@ -66,27 +66,39 @@ impl NestedAuraed {
         // TODO: handle expect
         let mut client_config =
             AuraeConfig::try_default().expect("file based config");
-        client_config.system.socket = format!(
+        let client_socket = format!(
             "{}/aurae-{}.sock",
             auraed_runtime.runtime_dir.to_string_lossy(),
             uuid::Uuid::new_v4(),
         );
 
+        client_config.system.socket = client_socket.clone();
+
         let auraed_path: PathBuf =
             auraed_runtime.auraed.clone().try_into().expect("path to auraed");
-        let mut command = Command::new(auraed_path);
 
-        let _ = command.current_dir("/").args([
+        let mut command = Command::new(auraed_path);
+        let _ = command.args([
             "--socket",
-            &client_config.system.socket,
+            &client_socket,
             "--nested", // NOTE: for now, the nested flag only signals for the code in the init module to not trigger (i.e., don't run the pid 1 code, run the non pid 1 code)
+            "--server-crt",
+            &auraed_runtime.server_crt.to_string_lossy(),
+            "--server-key",
+            &auraed_runtime.server_key.to_string_lossy(),
+            "--ca-crt",
+            &auraed_runtime.ca_crt.to_string_lossy(),
+            "--runtime-dir",
+            &auraed_runtime.runtime_dir.to_string_lossy(),
+            "--library-dir",
+            &auraed_runtime.library_dir.to_string_lossy(),
         ]);
 
         // We have a concern that the "command" API make change/break in the future and this
         // test is intended to help safeguard against that!
         // We check that the command we kept has the expected number of args following the call
         // to command.args, whose return value we ignored above.
-        assert_eq!(command.get_args().len(), 3);
+        assert_eq!(command.get_args().len(), 13);
 
         // *****************************************************************
         // ██████╗██╗      ██████╗ ███╗   ██╗███████╗██████╗

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -176,29 +176,6 @@ pub async fn run(
     {
         trace!("{:#?}", runtime);
 
-        let server_crt =
-            tokio::fs::read(&runtime.server_crt).await.with_context(|| {
-                format!(
-                    "Aurae requires a signed TLS certificate to run as a server, but failed to
-                    load: '{}'. Please see https://aurae.io/certs/ for information on best
-                    practices to quickly generate one.",
-                    runtime.server_crt.display()
-                )
-            })?;
-        let server_key = tokio::fs::read(&runtime.server_key).await?;
-        let server_identity = Identity::from_pem(server_crt, server_key);
-        info!("Register Server SSL Identity");
-
-        let ca_crt = tokio::fs::read(&runtime.ca_crt).await?;
-        let ca_crt_pem = Certificate::from_pem(ca_crt.clone());
-
-        let tls = ServerTlsConfig::new()
-            .identity(server_identity)
-            .client_ca_root(ca_crt_pem);
-
-        info!("Validating SSL Identity and Root Certificate Authority (CA)");
-        //let _log_collector = self.log_collector.clone();
-
         let runtime_dir = Path::new(&runtime.runtime_dir);
         // Create runtime directory
         tokio::fs::create_dir_all(runtime_dir).await.with_context(|| {
@@ -207,6 +184,39 @@ pub async fn run(
                 runtime.runtime_dir.display()
             )
         })?;
+
+
+        // We don't want TLS in cell context
+        let mut server = if context != AuraeContext::Cell {
+            let server_crt =
+                tokio::fs::read(&runtime.server_crt).await.with_context(|| {
+                    format!(
+                        "Aurae requires a signed TLS certificate to run as a server, but failed to
+                        load: '{}'. Please see https://aurae.io/certs/ for information on best
+                        practices to quickly generate one.",
+                        runtime.server_crt.display()
+                    )
+                })?;
+            let server_key = tokio::fs::read(&runtime.server_key).await?;
+            let server_identity = Identity::from_pem(server_crt, server_key);
+            info!("Register Server SSL Identity");
+
+            let ca_crt = tokio::fs::read(&runtime.ca_crt).await?;
+            let ca_crt_pem = Certificate::from_pem(ca_crt);
+
+            let tls = ServerTlsConfig::new()
+                .identity(server_identity)
+                .client_ca_root(ca_crt_pem);
+
+            info!("Validating SSL Identity and Root Certificate Authority (CA)");
+            //let _log_collector = self.log_collector.clone();
+
+            Server::builder()
+                    .tls_config(tls)
+                    .with_context(|| "gRPC server failed to configure tls")?
+        } else {
+            Server::builder()
+        };
 
         // Install eBPF probes in the host Aurae daemon
         let (_bpf_handle, perf_events) = if context == AuraeContext::Cell
@@ -281,9 +291,7 @@ pub async fn run(
         // Run the server concurrently
         // TODO: pass a known-good path to CellService to store any runtime data.
         let server_handle = tokio::spawn(async move {
-            Server::builder()
-                .tls_config(tls)
-                .with_context(|| "gRPC server failed to configure tls")?
+                server
                 .add_service(health_service)
                 .add_service(cell_service_server)
                 .add_service(discovery_service_server)

--- a/client/src/config/mod.rs
+++ b/client/src/config/mod.rs
@@ -81,7 +81,7 @@ impl AuraeConfig {
                     return Ok(config);
                 }
                 Err(e) => {
-                    println!("warning: failed to parse config at {path}: {e}");
+                    eprintln!("warning: failed to parse config at {path}: {e}");
                     continue;
                 }
             }


### PR DESCRIPTION
Because the daemon should not have access to the client key,
it should not be able to reuse the client auth to communicate with
the nested_auraed. Here we disable tls for proto message between
the daemon and the cell.

This not really intended to be merged as is, but mostly to trigger the discussion
on what are the security requirements for the communication between daemon and cells.  

This pr is on top of https://github.com/aurae-runtime/aurae/pull/442