### PR TITLE
fix CVE RUSTSEC-2020-0071

### DIFF
--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -47,7 +47,7 @@ aya = { version = ">=0.11", features = ["async_tokio"] }
 backoff = { version = "0.4.0", features = ["tokio"] }
 bytes = "1.2.1"
 clap = { workspace = true }
-chrono = "0.4.9"
+chrono = "0.4.23"
 clone3 = "0.2.3"
 fancy-regex = { workspace = true }
 futures = "0.3.23"


### PR DESCRIPTION
The version of `chrono` used by auraed depends on a vulnerable version of `time` crate. Updating `chrono` should fix this CVE.

This blocks pipeline, see [example](https://github.com/aurae-runtime/aurae/actions/runs/4359263923/jobs/7625884873#step:6:17).