### PR TITLE
Use `AuraedPath` to contain logic for locating auraed exe

### DIFF
--- a/auraed/src/auraed_path.rs
+++ b/auraed/src/auraed_path.rs
@@ -3,10 +3,12 @@ use std::path::PathBuf;
 
 const PROC_SELF_EXE: &str = "/proc/self/exe";
 
+/// Helper type to locate the auraed exe path.
 #[derive(Debug, Clone)]
 pub struct AuraedPath(Option<PathBuf>);
 
 impl AuraedPath {
+    /// Set an explicit path to the auraed exe
     pub fn from_path<P: Into<PathBuf>>(path: P) -> Self {
         Self(Some(path.into()))
     }

--- a/auraed/src/auraed_path.rs
+++ b/auraed/src/auraed_path.rs
@@ -1,0 +1,54 @@
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+
+const PROC_SELF_EXE: &str = "/proc/self/exe";
+
+#[derive(Debug, Clone)]
+pub struct AuraedPath(Option<PathBuf>);
+
+impl AuraedPath {
+    pub fn from_path<P: Into<PathBuf>>(path: P) -> Self {
+        Self(Some(path.into()))
+    }
+}
+
+impl Default for AuraedPath {
+    /// Defaults to reading the symbolic link from "/proc/self/exe".
+    /// During testing (i.e., `#[cfg(test)]`), the path is set to "auraed".
+    fn default() -> Self {
+        let path = {
+            // We use `None` to delay reading the symbolic link from /proc/self/exe, as /proc may not be mounted yet
+            #[cfg(not(test))]
+            let path = None;
+
+            // In unit tests, we cannot use /proc/self/exe since main.rs is not part of the test binary.
+            #[cfg(test)]
+            let path = Some("auraed".into());
+
+            path
+        };
+
+        Self(path)
+    }
+}
+
+impl TryFrom<AuraedPath> for PathBuf {
+    type Error = std::io::Error;
+
+    /// Can fail when relying on reading the symbolic link from /proc/self/exe, which is the default behavior.
+    fn try_from(value: AuraedPath) -> Result<Self, Self::Error> {
+        match value.0 {
+            Some(p) => Ok(p),
+            None => std::fs::read_link(PROC_SELF_EXE),
+        }
+    }
+}
+
+impl Display for AuraedPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Some(path) => path.display().fmt(f),
+            None => std::fmt::Display::fmt(PROC_SELF_EXE, f),
+        }
+    }
+}

--- a/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
+++ b/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
@@ -37,6 +37,7 @@ use nix::{
     sys::signal::{Signal, SIGKILL, SIGTERM},
     unistd::Pid,
 };
+use std::path::PathBuf;
 use std::{
     io::{self, ErrorKind},
     os::unix::process::{CommandExt, ExitStatusExt},
@@ -71,7 +72,9 @@ impl NestedAuraed {
             uuid::Uuid::new_v4(),
         );
 
-        let mut command = Command::new(&auraed_runtime.auraed);
+        let auraed_path: PathBuf =
+            auraed_runtime.auraed.clone().try_into().expect("path to auraed");
+        let mut command = Command::new(auraed_path);
 
         let _ = command.current_dir("/").args([
             "--socket",

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -61,7 +61,7 @@
 )]
 #![warn(clippy::unwrap_used)]
 
-use crate::auraed_path::AuraedPath;
+pub use crate::auraed_path::AuraedPath;
 use crate::ebpf::{
     BpfContext, SchedProcessForkTracepointProgram,
     SignalSignalGenerateTracepointProgram, TaskstatsExitKProbeProgram,

--- a/auraed/tests/common/mod.rs
+++ b/auraed/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use auraed::AuraedRuntime;
+use auraed::{AuraedPath, AuraedRuntime};
 use backoff::{
     backoff::Backoff, exponential::ExponentialBackoff,
     ExponentialBackoffBuilder, SystemClock,
@@ -66,7 +66,7 @@ async fn run_auraed() -> Client {
 
     let _ = tokio::spawn(async move {
         let mut runtime = AuraedRuntime::default();
-        runtime.auraed = "auraed".into();
+        runtime.auraed = AuraedPath::from_path("auraed");
 
         auraed::run(runtime, Some(socket), false, false).await.unwrap()
     });


### PR DESCRIPTION
In #447 @JeroenSoeters points out that we are reading `/proc/self/exe` too early (`/proc` may not be mounted, specifically when running as true PID 1).

The approach in this PR consolidates the logic for determining the path to auraed into a `AuraedPath` where we read `/proc/self/exe` when needed as opposed to when launching auraed.