### PR TITLE
Use outdated cache as backup in GHA

### DIFF
--- a/.github/workflows/001-tester-ubuntu-make-test.yml
+++ b/.github/workflows/001-tester-ubuntu-make-test.yml
@@ -64,6 +64,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: 000-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            000-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            000-${{ runner.os }}-cargo-
       - name: Install protoc-gen-doc in [ubuntu:latest]
         run: |
           wget https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.5.1/protoc-gen-doc_1.5.1_linux_amd64.tar.gz

--- a/.github/workflows/001-tester-ubuntu-make-test.yml
+++ b/.github/workflows/001-tester-ubuntu-make-test.yml
@@ -65,7 +65,6 @@ jobs:
             target/
           key: 000-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            000-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             000-${{ runner.os }}-cargo-
       - name: Install protoc-gen-doc in [ubuntu:latest]
         run: |

--- a/.github/workflows/101-tester-aurae-builder-make-pki-config-test.yml
+++ b/.github/workflows/101-tester-aurae-builder-make-pki-config-test.yml
@@ -65,7 +65,6 @@ jobs:
             target/
           key: 100-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            100-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             100-${{ runner.os }}-cargo-
       - name: Cargo Test [make pki config test]
         # This should remain the only command we execute as this matches the title of the file.

--- a/.github/workflows/101-tester-aurae-builder-make-pki-config-test.yml
+++ b/.github/workflows/101-tester-aurae-builder-make-pki-config-test.yml
@@ -64,6 +64,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: 100-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            100-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            100-${{ runner.os }}-cargo-
       - name: Cargo Test [make pki config test]
         # This should remain the only command we execute as this matches the title of the file.
         # The goal is for this to be easy to find from the GitHub dashboard.

--- a/.github/workflows/206-deny-check-aurae-builder.yml
+++ b/.github/workflows/206-deny-check-aurae-builder.yml
@@ -74,7 +74,6 @@ jobs:
             target/
           key: 200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             200-${{ runner.os }}-cargo-
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:

--- a/.github/workflows/206-deny-check-aurae-builder.yml
+++ b/.github/workflows/206-deny-check-aurae-builder.yml
@@ -73,6 +73,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: 200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            200-${{ runner.os }}-cargo-
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}

--- a/.github/workflows/207-udeps-check-aurae-builder-make-check-deps.yml
+++ b/.github/workflows/207-udeps-check-aurae-builder-make-check-deps.yml
@@ -64,7 +64,6 @@ jobs:
             target/
           key: 200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             200-${{ runner.os }}-cargo-
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/207-udeps-check-aurae-builder-make-check-deps.yml
+++ b/.github/workflows/207-udeps-check-aurae-builder-make-check-deps.yml
@@ -63,6 +63,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: 200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            200-${{ runner.os }}-cargo-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/.github/workflows/290-check-website-documentation-aurae-builder-make-docs.yml
+++ b/.github/workflows/290-check-website-documentation-aurae-builder-make-docs.yml
@@ -72,6 +72,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: 200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            200-${{ runner.os }}-cargo-
      - name: Docs (make docs docs-lint)
        run: |
          make docs docs-lint

--- a/.github/workflows/290-check-website-documentation-aurae-builder-make-docs.yml
+++ b/.github/workflows/290-check-website-documentation-aurae-builder-make-docs.yml
@@ -73,7 +73,6 @@ jobs:
             target/
           key: 200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            200-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
             200-${{ runner.os }}-cargo-
      - name: Docs (make docs docs-lint)
        run: |


### PR DESCRIPTION
Docs for [restore-keys](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)

Thinking an outdated cache is better than no cache

Hopefully helps with #461 