### PR TITLE
Nested without file config

### DIFF
--- a/auraed/src/cells/cell_service/cells/cell.rs
+++ b/auraed/src/cells/cell_service/cells/cell.rs
@@ -167,8 +167,6 @@ impl Cell {
         do_free!(self, kill(), broadcast_kill())
     }
 
-    // NOTE: Having this function return the Client means we need to make it async,
-    // or we need to make [Client::new] not async.
     pub fn client_socket(&self) -> Result<AuraeSocket> {
         let CellState::Allocated { nested_auraed, .. } = &self.state else {
             return Err(CellsError::CellNotAllocated {
@@ -176,7 +174,7 @@ impl Cell {
             })
         };
 
-        Ok(nested_auraed.client_config.system.socket.clone())
+        Ok(nested_auraed.client_socket.clone())
     }
 
     /// Returns the [CellName] of the [Cell]

--- a/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
+++ b/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
@@ -30,7 +30,7 @@
 
 use super::isolation_controls::{Isolation, IsolationControls};
 use crate::AURAED_RUNTIME;
-use client::{AuraeConfig, AuraeSocket};
+use client::AuraeSocket;
 use clone3::Flags;
 use nix::{
     libc::SIGCHLD,
@@ -52,7 +52,7 @@ pub struct NestedAuraed {
     pidfd: i32,
     #[allow(unused)]
     iso_ctl: IsolationControls,
-    pub client_config: AuraeConfig,
+    pub client_socket: AuraeSocket,
 }
 
 impl NestedAuraed {
@@ -63,15 +63,12 @@ impl NestedAuraed {
 
         let auraed_runtime = AURAED_RUNTIME.get().expect("runtime");
 
-        // TODO: handle expect
-        let mut client_config =
-            AuraeConfig::try_default().expect("file based config");
         let socket_path = format!(
             "{}/aurae-{}.sock",
             auraed_runtime.runtime_dir.to_string_lossy(),
             uuid::Uuid::new_v4(),
         );
-        client_config.system.socket = AuraeSocket::Path(socket_path.clone());
+        let client_socket = AuraeSocket::Path(socket_path.clone());
 
         let auraed_path: PathBuf =
             auraed_runtime.auraed.clone().try_into().expect("path to auraed");
@@ -168,7 +165,7 @@ impl NestedAuraed {
                 let process = procfs::process::Process::new(pid)
                     .map_err(|e| io::Error::new(ErrorKind::Other, e))?;
 
-                Ok(Self { process, pidfd, iso_ctl, client_config })
+                Ok(Self { process, pidfd, iso_ctl, client_socket })
             }
         }
     }

--- a/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
+++ b/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
@@ -74,17 +74,27 @@ impl NestedAuraed {
             auraed_runtime.auraed.clone().try_into().expect("path to auraed");
         let mut command = Command::new(auraed_path);
 
-        let _ = command.current_dir("/").args([
+        let _ = command.args([
             "--socket",
             &socket_path,
             "--nested", // NOTE: for now, the nested flag only signals for the code in the init module to not trigger (i.e., don't run the pid 1 code, run the non pid 1 code)
+            "--server-crt",
+            &auraed_runtime.server_crt.to_string_lossy(),
+            "--server-key",
+            &auraed_runtime.server_key.to_string_lossy(),
+            "--ca-crt",
+            &auraed_runtime.ca_crt.to_string_lossy(),
+            "--runtime-dir",
+            &auraed_runtime.runtime_dir.to_string_lossy(),
+            "--library-dir",
+            &auraed_runtime.library_dir.to_string_lossy(),
         ]);
 
         // We have a concern that the "command" API make change/break in the future and this
         // test is intended to help safeguard against that!
         // We check that the command we kept has the expected number of args following the call
         // to command.args, whose return value we ignored above.
-        assert_eq!(command.get_args().len(), 3);
+        assert_eq!(command.get_args().len(), 13);
 
         // *****************************************************************
         // ██████╗██╗      ██████╗ ███╗   ██╗███████╗██████╗

--- a/auraed/tests/common/mod.rs
+++ b/auraed/tests/common/mod.rs
@@ -103,21 +103,21 @@ pub async fn auraed_client() -> Client {
     CLIENT.get_or_init(inner).await.clone()
 }
 
-pub async fn remote_auraed_client(ip: String, scope_id: u32) -> Client {
-    let client_config = AuraeConfig {
-        auth: AuthConfig {
-            ca_crt: "/etc/aurae/pki/ca.crt".to_string(),
-            client_crt: "/etc/aurae/pki/_signed.client.nova.crt".to_string(),
-            client_key: "/etc/aurae/pki/client.nova.key".to_string(),
-        },
-        system: SystemConfig { socket: AuraeSocket::IPv6 { ip, scope_id } },
-    };
-    let client = Client::new(client_config.clone())
-        .await
-        .expect("failed to create client");
-
-    client
-}
+// pub async fn remote_auraed_client(ip: String, scope_id: u32) -> Client {
+//     let client_config = AuraeConfig {
+//         auth: AuthConfig {
+//             ca_crt: "/etc/aurae/pki/ca.crt".to_string(),
+//             client_crt: "/etc/aurae/pki/_signed.client.nova.crt".to_string(),
+//             client_key: "/etc/aurae/pki/client.nova.key".to_string(),
+//         },
+//         system: SystemConfig { socket: AuraeSocket::IPv6 { ip, scope_id } },
+//     };
+//     let client = Client::new(client_config.clone())
+//         .await
+//         .expect("failed to create client");
+//
+//     client
+// }
 
 pub fn default_retry_strategy() -> ExponentialBackoff<SystemClock> {
     ExponentialBackoffBuilder::new()


### PR DESCRIPTION
Since the socket between daemon and cells doesn't use TLS anymore,
we only need to keep the `AuraedSocket` around, no need to load
client config file.

Allow to run auraed without config files

