### PR TITLE
Fix parsing a socket path in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "client-macros",
+ "if_chain",
  "proto",
  "serde",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ clap = { version = "4.1.1", features = ["derive"] }
 fancy-regex = "0.11.0"
 futures-util = "0.3.26"
 heck = "0.4.0"
+if_chain = "1.0.2"
 lazy_static = "1.4.0"
 nix = "0.26.2"
 proc-macro2 = "1.0"

--- a/Makefile
+++ b/Makefile
@@ -206,15 +206,15 @@ $(1)-test: musl $(GEN_RS) $(GEN_TS) auraed
 	$(cargo) test $(2) -p $(1)
 
 .PHONY: $(1)-test-all
-$(1)-test-all: musl $(GEN_RS) $(GEN_TS) $(1)
+$(1)-test-all: musl $(GEN_RS) $(GEN_TS) auraed
 	$(root_cargo) test $(2) -p $(1) -- --include-ignored
 
 .PHONY: $(1)-test-integration
-$(1)-test-integration: musl $(GEN_RS) $(GEN_TS) $(1)
+$(1)-test-integration: musl $(GEN_RS) $(GEN_TS) auraed
 	$(root_cargo) test $(2) -p $(1) --test '*' -- --include-ignored
 
 .PHONY: $(1)-test-watch
-$(1)-test-watch: musl $(GEN_RS) $(GEN_TS) $(1) # Use cargo-watch to continuously run a test (e.g. make $(1)-test-watch name=path::to::test)
+$(1)-test-watch: musl $(GEN_RS) $(GEN_TS) auraed # Use cargo-watch to continuously run a test (e.g. make $(1)-test-watch name=path::to::test)
 	$(root_cargo) watch -- $(cargo) test $(2) -p $(1) $(name) -- --include-ignored --nocapture
 
 .PHONY: $(1)-build

--- a/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
+++ b/auraed/src/cells/cell_service/cells/nested_auraed/nested_auraed.rs
@@ -68,7 +68,8 @@ impl NestedAuraed {
             auraed_runtime.runtime_dir.to_string_lossy(),
             uuid::Uuid::new_v4(),
         );
-        let client_socket = AuraeSocket::Path(socket_path.clone());
+
+        let client_socket = AuraeSocket::Path(socket_path.clone().into());
 
         let auraed_path: PathBuf =
             auraed_runtime.auraed.clone().try_into().expect("path to auraed");

--- a/auraed/tests/common/mod.rs
+++ b/auraed/tests/common/mod.rs
@@ -63,7 +63,9 @@ async fn run_auraed() -> Client {
             client_crt: "/etc/aurae/pki/_signed.client.nova.crt".to_string(),
             client_key: "/etc/aurae/pki/client.nova.key".to_string(),
         },
-        system: SystemConfig { socket: AuraeSocket::Path(socket.clone()) },
+        system: SystemConfig {
+            socket: AuraeSocket::Path(socket.clone().into()),
+        },
     };
 
     let _ = tokio::spawn(async move {

--- a/auraescript/src/builtin/auraescript_client.rs
+++ b/auraescript/src/builtin/auraescript_client.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
-use client::{Client, AuraeConfig};
+use client::{AuraeConfig, Client};
 use deno_core::{OpState, Resource, ResourceId};
 use std::{cell::RefCell, rc::Rc};
 
 // `AuraeConfig` `try_default`
 #[deno_core::op]
 pub(crate) async fn as__aurae_config__try_default(
-    op_state: Rc<RefCell<OpState>>
+    op_state: Rc<RefCell<OpState>>,
 ) -> Result<ResourceId> {
     let config = AuraeConfig::try_default()?;
     let mut op_state = op_state.borrow_mut();
@@ -23,7 +23,8 @@ pub(crate) async fn as__aurae_config__from_options(
     client_key: String,
     socket: String,
 ) -> ResourceId {
-    let config = AuraeConfig::from_options(ca_crt, client_crt, client_key, socket);
+    let config =
+        AuraeConfig::from_options(ca_crt, client_crt, client_key, socket);
     let mut op_state = op_state.borrow_mut();
     op_state.resource_table.add(AuraeScriptConfig(config))
 }
@@ -34,20 +35,17 @@ pub(crate) async fn as__aurae_config__parse_from_file(
     op_state: Rc<RefCell<OpState>>,
     path: String,
 ) -> Result<ResourceId> {
-    let config = AuraeConfig::parse_from_file(path)?;
+    let config = AuraeConfig::parse_from_toml_file(path)?;
     let mut op_state = op_state.borrow_mut();
     let rid = op_state.resource_table.add(AuraeScriptConfig(config));
     Ok(rid)
 }
-
 
 // Re export AuraeConfig in auraescript to be able
 // to impl Resource on it
 pub(crate) struct AuraeScriptConfig(pub AuraeConfig);
 
 impl Resource for AuraeScriptConfig {} // Blank impl
-
-
 
 // Create a `Client` with given `AuraeConfig`
 #[deno_core::op]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = { workspace = true }
+if_chain = { workspace = true }
 macros = { package = "client-macros", path = "macros" }
 proto = { workspace = true }
 serde = { workspace = true }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -120,7 +120,10 @@ impl Client {
                     .await
             }
             AuraeSocket::IPv6 { ip: mut socket, scope_id } => {
-                socket.set_scope_id(scope_id);
+                if let Some(scope_id) = scope_id {
+                    socket.set_scope_id(scope_id);
+                }
+
                 endpoint
                     .connect_with_connector(service_fn(move |_: Uri| {
                         TcpStream::connect(socket)

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -33,8 +33,6 @@
 //! Manages authenticating with remote Aurae instances, as well as searching
 //! the local filesystem for configuration and authentication material.
 
-use std::net::SocketAddrV6;
-
 use crate::config::{AuraeConfig, CertMaterial, ClientCertDetails};
 use crate::AuraeSocket;
 use thiserror::Error;
@@ -121,9 +119,7 @@ impl Client {
                     }))
                     .await
             }
-            AuraeSocket::IPv6 { ip, scope_id } => {
-                let mut socket =
-                    ip.parse::<SocketAddrV6>().expect("invalid ip address");
+            AuraeSocket::IPv6 { ip: mut socket, scope_id } => {
                 socket.set_scope_id(scope_id);
                 endpoint
                     .connect_with_connector(service_fn(move |_: Uri| {

--- a/client/src/config/system_config.rs
+++ b/client/src/config/system_config.rs
@@ -28,19 +28,63 @@
  *                                                                            *
 \* -------------------------------------------------------------------------- */
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub enum AuraeSocket {
-    Path(String),
-    IPv6 { ip: String, scope_id: u32 },
-}
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::fmt::Formatter;
+use std::net::SocketAddrV6;
+use std::path::PathBuf;
 
 /// The system configuration for AuraeScript.
 ///
 /// Used to define settings for AuraeScript at runtime.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct SystemConfig {
     /// Socket to connect the client to.  Can be a path (unix socket) or a network socket address.
     pub socket: AuraeSocket,
+}
+
+#[derive(Debug, Clone)]
+pub enum AuraeSocket {
+    Path(PathBuf),
+    IPv6 { ip: SocketAddrV6, scope_id: u32 },
+}
+
+impl<'de> Deserialize<'de> for AuraeSocket {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_string(AuraeSocketVisitor)
+    }
+}
+
+struct AuraeSocketVisitor;
+
+impl<'de> Visitor<'de> for AuraeSocketVisitor {
+    type Value = AuraeSocket;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("a path (unix socket) or a network socket address")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_string(v.to_string())
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        self.visit_string(v.to_string())
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(AuraeSocket::Path(PathBuf::from(v)))
+    }
 }

--- a/client/src/config/system_config.rs
+++ b/client/src/config/system_config.rs
@@ -41,6 +41,13 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Deserialize)]
 pub struct SystemConfig {
     /// Socket to connect the client to.  Can be a path (unix socket) or a network socket address.
+    ///
+    /// When deserializing from a string, the deserializer will try to parse a valid value in the following order:
+    /// - IPv6 with scope id (e.g., "[fe80::2]:8080%4")
+    /// - IPv6 without scope id (e.g., "[fe80::2]:8080")
+    /// - Otherwise a path
+    ///
+    /// scope id must be a valid u32, otherwise it will be assumed a path
     pub socket: AuraeSocket,
 }
 

--- a/examples/cells.ts
+++ b/examples/cells.ts
@@ -31,8 +31,8 @@
 import * as aurae from "../auraescript/gen/aurae.ts";
 import * as cells from "../auraescript/gen/cells.ts";
 
-let client = await aurae.createClient();
-let cellService = new cells.CellServiceClient(client);
+const client = await aurae.createClient();
+const cellService = new cells.CellServiceClient(client);
 const nestedCellName = "ae-sleeper-cell/nested-sleeper"
 const cellName = "ae-sleeper-cell";
 


### PR DESCRIPTION
By default, the toml crate does not handle enum (de)serialization. This PR implements the traits needed by serde to enable deserializing an `AuraeSocket`. Currently it assumes the config is specifying a `Path`, but I would think we also want to support specifying a `SocketAddrV6` at some point.