### PR TITLE
Pin youki crates to commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 [[package]]
 name = "libcgroups"
 version = "0.0.4"
-source = "git+https://github.com/containers/youki?branch=main#0c907571a899f9715d08be7672548acc1883f1b7"
+source = "git+https://github.com/containers/youki?rev=0c907571a899f9715d08be7672548acc1883f1b7#0c907571a899f9715d08be7672548acc1883f1b7"
 dependencies = [
  "anyhow",
  "fixedbitset",
@@ -2527,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "libcontainer"
 version = "0.0.4"
-source = "git+https://github.com/containers/youki?branch=main#0c907571a899f9715d08be7672548acc1883f1b7"
+source = "git+https://github.com/containers/youki?rev=0c907571a899f9715d08be7672548acc1883f1b7#0c907571a899f9715d08be7672548acc1883f1b7"
 dependencies = [
  "anyhow",
  "bitflags 2.0.2",

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -55,8 +55,8 @@ ipnetwork = "0.20.0"
 iter_tools = "0.1.4"
 libc = "0.2.140" # TODO: Nix comes with libc, can we rely on that?
 lazy_static = { workspace = true }
-libcgroups = {  git = "https://github.com/containers/youki", branch = "main", default-features = false, features = ["v2"] }
-libcontainer = { git = "https://github.com/containers/youki", branch = "main", features = ["v2"], default-features = false }
+libcgroups = { git = "https://github.com/containers/youki", rev = "0c907571a899f9715d08be7672548acc1883f1b7", default-features = false, features = ["v2"] }
+libcontainer = { git = "https://github.com/containers/youki", rev = "0c907571a899f9715d08be7672548acc1883f1b7", default-features = false, features = ["v2"] }
 log = "0.4.17"
 netlink-packet-route = "0.13.0" # Used for netlink_packet_route::rtnl::address::nlas definition
 nix = { workspace = true, features = ["sched"] }


### PR DESCRIPTION
Since youki is in early development, relying on its main branch has been causing issues where auraed ends up breaking unexpectedly as changes are made upstream. I would have expected our Cargo.lock to save us, but it hasn't, so these changes make the dependencies rely on the specific commit instead of branch.

Relying on a branch seems like it would be pretty unstable in general (vs a commit or tag). We also rely on a branch for aya in our ebpf crates. I wanted to change that in this PR as well, but I couldn't get the ebpf crates to build (likely due to me being on a aarch64 system and aya has changed the dependencies it needs, which I could not successfully install). 