### PR TITLE
Fix compilation error caused by youki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,11 +48,11 @@ version = "0.0.0"
 dependencies = [
  "heck",
  "itertools",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.60",
  "proto-reader",
  "protobuf",
  "protobuf-parse",
- "quote 1.0.23",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -154,8 +154,8 @@ checksum = "cf94863c5fdfee166d0907c44e5fee970123b2b7307046d35d1e671aa93afbba"
 dependencies = [
  "darling 0.13.4",
  "pmutil",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "swc_macros_common",
  "syn 1.0.107",
 ]
@@ -190,8 +190,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -201,8 +201,8 @@ version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -297,11 +297,11 @@ name = "auraescript_macros"
 version = "0.0.0"
 dependencies = [
  "heck",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.60",
  "proto-reader",
  "protobuf",
  "protobuf-parse",
- "quote 1.0.23",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -465,9 +465,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.0.2"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
 
 [[package]]
 name = "block-buffer"
@@ -633,8 +633,8 @@ checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -668,9 +668,9 @@ name = "client-macros"
 version = "0.0.0"
 dependencies = [
  "heck",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.60",
  "proto-reader",
- "quote 1.0.23",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -798,7 +798,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.23",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -858,8 +858,8 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "scratch",
  "syn 1.0.107",
 ]
@@ -876,8 +876,8 @@ version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -909,8 +909,8 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "strsim",
  "syn 1.0.107",
 ]
@@ -923,8 +923,8 @@ checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "strsim",
  "syn 1.0.107",
 ]
@@ -936,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote 1.0.23",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -947,7 +947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core 0.14.2",
- "quote 1.0.23",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -1276,7 +1276,7 @@ dependencies = [
  "md-5",
  "md4",
  "once_cell",
- "path-clean 0.1.0",
+ "path-clean",
  "rand",
  "regex",
  "ripemd",
@@ -1297,8 +1297,8 @@ dependencies = [
  "once_cell",
  "pmutil",
  "proc-macro-crate",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "regex",
  "syn 1.0.107",
 ]
@@ -1466,8 +1466,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
  "darling 0.14.2",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -1488,8 +1488,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "rustc_version 0.4.0",
  "syn 1.0.107",
 ]
@@ -1585,8 +1585,8 @@ dependencies = [
  "byteorder",
  "lazy_static",
  "proc-macro-error",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -1657,8 +1657,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -1669,7 +1669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b940da354ae81ef0926c5eaa428207b8f4f091d3956c891dfbd124162bed99"
 dependencies = [
  "pmutil",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.60",
  "swc_macros_common",
  "syn 1.0.107",
 ]
@@ -1725,6 +1725,12 @@ checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "ff"
@@ -1797,7 +1803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0981e470d2ab9f643df3921d54f1952ea100c39fdb6a3fdc820e20d2291df6c"
 dependencies = [
  "pmutil",
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.60",
  "swc_macros_common",
  "syn 1.0.107",
 ]
@@ -1887,8 +1893,8 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -1980,8 +1986,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -2343,8 +2349,8 @@ checksum = "1c068d4c6b922cd6284c609cfa6dec0e41615c9c5a1a4ba729a970d8daba05fb"
 dependencies = [
  "Inflector",
  "pmutil",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -2506,50 +2512,49 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libcgroups"
-version = "0.0.4"
-source = "git+https://github.com/containers/youki?rev=0c907571a899f9715d08be7672548acc1883f1b7#0c907571a899f9715d08be7672548acc1883f1b7"
+version = "0.0.5"
+source = "git+https://github.com/containers/youki?rev=f4e7e300e6be7a4ea758a436218b9db1b39c69cd#f4e7e300e6be7a4ea758a436218b9db1b39c69cd"
 dependencies = [
- "anyhow",
  "fixedbitset",
- "log",
  "nix 0.26.2",
  "oci-spec",
  "procfs 0.15.1",
  "serde",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "libcontainer"
-version = "0.0.4"
-source = "git+https://github.com/containers/youki?rev=0c907571a899f9715d08be7672548acc1883f1b7#0c907571a899f9715d08be7672548acc1883f1b7"
+version = "0.0.5"
+source = "git+https://github.com/containers/youki?rev=f4e7e300e6be7a4ea758a436218b9db1b39c69cd#f4e7e300e6be7a4ea758a436218b9db1b39c69cd"
 dependencies = [
- "anyhow",
- "bitflags 2.0.2",
+ "bitflags 2.3.2",
  "caps",
  "chrono",
  "clone3",
- "crossbeam-channel",
- "fastrand",
+ "fastrand 2.0.0",
  "futures",
  "libc",
  "libcgroups",
- "log",
- "mio",
  "nix 0.26.2",
  "oci-spec",
- "path-clean 1.0.1",
+ "once_cell",
  "prctl",
  "procfs 0.15.1",
+ "regex",
  "rust-criu",
+ "safe-path",
  "serde",
  "serde_json",
- "syscalls",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3001,8 +3006,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be1598bf1c313dcdd12092e3f1920f463462525a21b7b4e11b4168353d0123e"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -3026,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214b837f7dde5026f2028ead5ae720073277c19f82ff85623b142c39d4b843e7"
+checksum = "cf77d2eace1f4909b081d231d1ad3570ba3448ae95290ab701314faaee1b611a"
 dependencies = [
  "derive_builder",
  "getset",
@@ -3039,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -3149,12 +3154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
 
 [[package]]
-name = "path-clean"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
-
-[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3224,8 +3223,8 @@ dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro-hack",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -3253,8 +3252,8 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -3304,8 +3303,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -3372,8 +3371,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
  "version_check",
 ]
@@ -3384,8 +3383,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "version_check",
 ]
 
@@ -3406,9 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -3461,8 +3460,8 @@ checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -3480,10 +3479,10 @@ dependencies = [
 name = "proto-reader"
 version = "0.0.0"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.60",
  "protobuf",
  "protobuf-parse",
- "quote 1.0.23",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -3564,11 +3563,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
- "proc-macro2 1.0.50",
+ "proc-macro2 1.0.60",
 ]
 
 [[package]]
@@ -3621,13 +3620,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -3636,7 +3635,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3644,6 +3643,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "remove_dir_all"
@@ -3888,6 +3893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
+name = "safe-path"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980abdd3220aa19b67ca3ea07b173ca36383f18ae48cde696d90c8af39447ffb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,8 +4048,8 @@ version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -4057,8 +4071,8 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -4118,8 +4132,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "079a83df15f85d89a68d64ae1238f142f172b1fa915d0d76b26a7cba1b659a69"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -4219,8 +4233,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28ef0b01435ca8679e00e76b31d32aa7cc596614b49e58b3bc5e2fcf685fa5a"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -4355,8 +4369,8 @@ checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
 dependencies = [
  "phf_generator",
  "phf_shared",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
 ]
 
 [[package]]
@@ -4366,8 +4380,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41491e23e7db79343236a6ced96325ff132eb09e29ac4c5b8132b9c55aaaae89"
 dependencies = [
  "pmutil",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "swc_macros_common",
  "syn 1.0.107",
 ]
@@ -4445,8 +4459,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb64bc03d90fd5c90d6ab917bb2b1d7fbd31957df39e31ea24a3f554b4372251"
 dependencies = [
  "pmutil",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "swc_macros_common",
  "syn 1.0.107",
 ]
@@ -4494,8 +4508,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0159c99f81f52e48fe692ef7af1b0990b45d3006b14c6629be0b1ffee1b23aea"
 dependencies = [
  "pmutil",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "swc_macros_common",
  "syn 1.0.107",
 ]
@@ -4578,8 +4592,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf907935ec5492256b523ae7935a824d9fdc0368dcadc41375bad0dca91cd8b"
 dependencies = [
  "pmutil",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "swc_macros_common",
  "syn 1.0.107",
 ]
@@ -4684,8 +4698,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c20468634668c2bbab581947bb8c75c97158d5a6959f4ba33df20983b20b4f6"
 dependencies = [
  "pmutil",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -4696,8 +4710,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4be988307882648d9bc7c71a6a73322b7520ef0211e920489a98f8391d8caa2"
 dependencies = [
  "pmutil",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -4719,8 +4733,8 @@ checksum = "6098b717cfd4c85f5cddec734af191dbce461c39975ed567c32ac6d0c6d61a6d"
 dependencies = [
  "Inflector",
  "pmutil",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "swc_macros_common",
  "syn 1.0.107",
 ]
@@ -4742,8 +4756,19 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+dependencies = [
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "unicode-ident",
 ]
 
@@ -4759,21 +4784,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
  "unicode-xid 0.2.4",
-]
-
-[[package]]
-name = "syscalls"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5370cb0d74115b12ddd7feb517742dbaaf4aae9e3c10ff0edc7c19404935075b"
-dependencies = [
- "cc",
- "serde",
- "serde_repr",
 ]
 
 [[package]]
@@ -4794,7 +4808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
- "fastrand",
+ "fastrand 1.8.0",
  "libc",
  "redox_syscall",
  "remove_dir_all",
@@ -4823,8 +4837,8 @@ name = "test-helpers-macros"
 version = "0.0.0"
 dependencies = [
  "heck",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -4839,22 +4853,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
- "syn 1.0.107",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -4957,8 +4971,8 @@ version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -5205,8 +5219,8 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -5375,8 +5389,8 @@ checksum = "54de46f980cea7b2ae8d8f7f9f1c35cf7062c68343e99345ef73758f8e60975a"
 dependencies = [
  "lazy_static",
  "libc",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "regex",
  "syn 1.0.107",
 ]
@@ -5564,8 +5578,8 @@ name = "validation_macros"
 version = "0.0.0"
 dependencies = [
  "heck",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
 ]
 
@@ -5625,8 +5639,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
 ]
 
 [[package]]
@@ -5687,8 +5701,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
@@ -5711,7 +5725,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
- "quote 1.0.23",
+ "quote 1.0.28",
  "wasm-bindgen-macro-support",
 ]
 
@@ -5721,8 +5735,8 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -5982,8 +5996,8 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2 1.0.50",
- "quote 1.0.23",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
  "syn 1.0.107",
  "synstructure",
 ]

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -55,12 +55,12 @@ ipnetwork = "0.20.0"
 iter_tools = "0.1.4"
 libc = "0.2.140" # TODO: Nix comes with libc, can we rely on that?
 lazy_static = { workspace = true }
-libcgroups = { git = "https://github.com/containers/youki", rev = "0c907571a899f9715d08be7672548acc1883f1b7", default-features = false, features = ["v2"] }
-libcontainer = { git = "https://github.com/containers/youki", rev = "0c907571a899f9715d08be7672548acc1883f1b7", default-features = false, features = ["v2"] }
+libcgroups = { git = "https://github.com/containers/youki", rev = "f4e7e300e6be7a4ea758a436218b9db1b39c69cd", default-features = false, features = ["v2"] }
+libcontainer = { git = "https://github.com/containers/youki", rev = "f4e7e300e6be7a4ea758a436218b9db1b39c69cd", default-features = false, features = ["v2"] }
 log = "0.4.17"
 netlink-packet-route = "0.13.0" # Used for netlink_packet_route::rtnl::address::nlas definition
 nix = { workspace = true, features = ["sched"] }
-oci-spec = "0.6.0"
+oci-spec = "0.6.1"
 once_cell = "1"
 procfs = "0.14.2"
 proto = { workspace = true }

--- a/auraed/src/cells/cell_service/cells/cgroups/cgroup.rs
+++ b/auraed/src/cells/cell_service/cells/cgroups/cgroup.rs
@@ -84,7 +84,10 @@ impl Cgroup {
         if let Err(e) = leaf.add_task(nested_auraed_pid) {
             let _ = leaf.remove();
             let _ = non_leaf.remove();
-            return Err(CgroupsError::AddTaskToCgroup { cell_name, source: e });
+            return Err(CgroupsError::AddTaskToCgroup {
+                cell_name,
+                source: e.into(),
+            });
         }
 
         let builder = LinuxResourcesBuilder::default();
@@ -170,7 +173,10 @@ impl Cgroup {
             // libcgroups takes care of killing any processes it finds
             let _ = leaf.remove();
             let _ = non_leaf.remove();
-            return Err(CgroupsError::CreateCgroup { cell_name, source: e });
+            return Err(CgroupsError::CreateCgroup {
+                cell_name,
+                source: e.into(),
+            });
         }
 
         Ok(Self { cell_name })
@@ -185,7 +191,7 @@ impl Cgroup {
 
         manager.add_task(pid).map_err(|e| CgroupsError::AddTaskToCgroup {
             cell_name: self.cell_name.clone(),
-            source: e,
+            source: e.into(),
         })
     }
 
@@ -198,7 +204,7 @@ impl Cgroup {
 
         leaf.remove().map_err(|e| CgroupsError::DeleteCgroup {
             cell_name: self.cell_name.clone(),
-            source: e,
+            source: e.into(),
         })?;
 
         let non_leaf = v2::manager::Manager::new(
@@ -209,7 +215,7 @@ impl Cgroup {
 
         non_leaf.remove().map_err(|e| CgroupsError::DeleteCgroup {
             cell_name: self.cell_name.clone(),
-            source: e,
+            source: e.into(),
         })
     }
 
@@ -233,7 +239,7 @@ impl Cgroup {
 
         non_leaf.stats().map_err(|e| CgroupsError::ReadStats {
             cell_name: self.cell_name.clone(),
-            source: e,
+            source: e.into(),
         })
     }
 


### PR DESCRIPTION
Apologize for breaking the build. Historically, we did not have a good consumer for the `libcontainer` except `youki` cli. This lead us to not focus on the other usecases for the `libcontainer`. The error previously observed is fixed on the `youki` side.

I updated the commit to latest fix for `youki` and the build passes. I believe `youki` is releasing a new proper version `0.1.0` soon, so we can switch to that version after the release is made. In this way, we don't have to track specific commits.

For the `oci-spec` issue, I believe a good approach is for `youki` to re-export the `oci-spec-rs` that it uses, so there is no version mis-match.