### PR TITLE
Fix cargo-deny config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,6 @@ dependencies = [
  "tonic",
  "tonic-health",
  "tracing",
- "tracing-log 0.1.4",
  "tracing-subscriber",
  "uuid",
  "validation",
@@ -5911,17 +5910,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -5946,7 +5934,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6337,9 +6337,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -6347,9 +6347,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -6374,9 +6374,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote 1.0.33",
  "wasm-bindgen-macro-support",
@@ -6384,9 +6384,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -6397,9 +6397,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-streams"
@@ -6732,18 +6732,18 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -55,8 +55,12 @@ ipnetwork = "0.20.0"
 iter_tools = "0.1.4"
 libc = "0.2.147" # TODO: Nix comes with libc, can we rely on that?
 lazy_static = { workspace = true }
-libcgroups = { git = "https://github.com/containers/youki", rev = "f4e7e300e6be7a4ea758a436218b9db1b39c69cd", default-features = false, features = ["v2"] }
-libcontainer = { git = "https://github.com/containers/youki", rev = "f4e7e300e6be7a4ea758a436218b9db1b39c69cd", default-features = false, features = ["v2"] }
+libcgroups = { git = "https://github.com/containers/youki", rev = "f4e7e300e6be7a4ea758a436218b9db1b39c69cd", default-features = false, features = [
+    "v2",
+] }
+libcontainer = { git = "https://github.com/containers/youki", rev = "f4e7e300e6be7a4ea758a436218b9db1b39c69cd", default-features = false, features = [
+    "v2",
+] }
 log = "0.4.17"
 netlink-packet-route = "0.13.0" # Used for netlink_packet_route::rtnl::address::nlas definition
 nix = { workspace = true, features = ["sched"] }
@@ -69,12 +73,20 @@ serde_json.workspace = true
 serde.workspace = true
 syslog-tracing = "0.1.0"
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["fs", "macros", "net", "parking_lot", "process", "rt-multi-thread", "signal", "sync"] }
+tokio = { workspace = true, features = [
+    "fs",
+    "macros",
+    "net",
+    "parking_lot",
+    "process",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+] }
 tokio-stream = { version = "0.1.14", features = ["net", "sync"] }
 tonic = { workspace = true, features = ["tls"] }
 tonic-health = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
-tracing-log = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 uuid = { workspace = true }
 validation = { workspace = true, features = ["regex", "tonic"] }

--- a/deny.toml
+++ b/deny.toml
@@ -171,14 +171,14 @@ exceptions = [
 name = "libcgroups"
 expression = "Apache-2.0"
 license-files = [
-    { path = "LICENSE", hash = 0x8767455a }
+    { path = "../../LICENSE", hash = 0x8767455a }
 ]
 
 [[licenses.clarify]]
 name = "libcontainer"
 expression = "Apache-2.0"
 license-files = [
-    { path = "LICENSE", hash = 0x8767455a }
+    { path = "../../LICENSE", hash = 0x8767455a }
 ]
 
 # https://github.com/briansmith/ring/blob/main/LICENSE (ISC AND MIT AND OpenSSL)

--- a/deny.toml
+++ b/deny.toml
@@ -59,38 +59,19 @@ feature-depth = 1
 [advisories]
 # The path where the advisory database is cloned/fetched into
 db-path = "~/.cargo/advisory-db"
-# The url(s) of the advisory databases to use
-db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "warn"
-# The lint level for unmaintained crates
+db-urls = ["https://github.com/RustSec/advisory-db"]
+vulnerability = "deny"
 unmaintained = "warn"
-# The lint level for crates that have been yanked from their source registry
+notice = "deny"
 yanked = "warn"
-# The lint level for crates with security notices. Note that as of
-# 2019-12-17 there are no security notice advisories in
-# https://github.com/rustsec/advisory-db
-notice = "warn"
-# A list of advisory IDs to ignore. Note that ignored advisories will still
-# output a note when they are encountered.
+unsound = "warn"
+severity-threshold = "medium"
 ignore = [
-    #"RUSTSEC-0000-0000",
+    # Marvin Attack: potential key recovery through timing sidechannels in `rsa v0.7.2` crate
+    # No available fix as of 2024-01-14
+    "RUSTSEC-2023-0071",
 ]
-# Threshold for security vulnerabilities, any vulnerability with a CVSS score
-# lower than the range specified will be ignored. Note that ignored advisories
-# will still output a note when they are encountered.
-# * None - CVSS Score 0.0
-# * Low - CVSS Score 0.1 - 3.9
-# * Medium - CVSS Score 4.0 - 6.9
-# * High - CVSS Score 7.0 - 8.9
-# * Critical - CVSS Score 9.0 - 10.0
-#severity-threshold =
 
-# If this is true, then cargo deny will use the git executable to fetch advisory database.
-# If this is false, then it uses a built-in git library.
-# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
-# See Git Authentication for more information about setting up git authentication.
-#git-fetch-with-cli = true
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
@@ -150,52 +131,27 @@ exceptions = [
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
 # licensing information
-#[[licenses.clarify]]
-# The name of the crate the clarification applies to
-#name = "ring"
-# The optional version constraint for the crate
-#version = "*"
-# The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
-# One or more files in the crate's source used as the "source of truth" for
-# the license expression. If the contents match, the clarification will be used
-# when running the license check, otherwise the clarification will be ignored
-# and the crate will be checked normally, which may produce warnings or errors
-# depending on the rest of your configuration
-#license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    #{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
-
 [[licenses.clarify]]
 name = "libcgroups"
 expression = "Apache-2.0"
-license-files = [
-    { path = "../../LICENSE", hash = 0x8767455a }
-]
+license-files = [{ path = "../../LICENSE", hash = 0x8767455a }]
 
 [[licenses.clarify]]
 name = "libcontainer"
 expression = "Apache-2.0"
-license-files = [
-    { path = "../../LICENSE", hash = 0x8767455a }
-]
+license-files = [{ path = "../../LICENSE", hash = 0x8767455a }]
 
 # https://github.com/briansmith/ring/blob/main/LICENSE (ISC AND MIT AND OpenSSL)
 [[licenses.clarify]]
 name = "ring"
 expression = "LicenseRef-ring"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 # https://github.com/briansmith/webpki/blob/main/LICENSE (ISC-style)
 [[licenses.clarify]]
 name = "webpki"
 expression = "LicenseRef-webpki"
-license-files = [
-    { path = "LICENSE", hash = 0x001c7e6c }
-]
+license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only


### PR DESCRIPTION
Fixes the path to the license for `libcontainer` and `libcgroups` crates in `deny.toml`. This resolves CI [failures](https://github.com/aurae-runtime/aurae/actions/runs/7158741508/job/19491179286) we're seeing from `cargo-deny`.

Also upgrades the `cargo-deny` config to `deny` for medium+ severity vulnerabilities, ignoring [`RUSTSEC-2023-0071`](https://rustsec.org/advisories/RUSTSEC-2023-0071) for now since it does not have a current fix.

Fixes #460