### PR TITLE
chore(deps): address RUSTSEC-2024-0344 & yanked libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,15 +1014,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "fiat-crypto",
- "platforms",
  "rustc_version 0.4.0",
  "subtle",
  "zeroize",
@@ -3230,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libcgroups"
@@ -4182,12 +4181,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "pmutil"

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -53,7 +53,7 @@ fancy-regex = { workspace = true }
 futures = "0.3.28"
 ipnetwork = "0.20.0"
 iter_tools = "0.1.4"
-libc = "0.2.147" # TODO: Nix comes with libc, can we rely on that?
+libc = "0.2.155" # TODO: Nix comes with libc, can we rely on that?
 lazy_static = { workspace = true }
 libcgroups = { git = "https://github.com/containers/youki", rev = "f4e7e300e6be7a4ea758a436218b9db1b39c69cd", default-features = false, features = [
     "v2",


### PR DESCRIPTION
Fixes findings found in cargo-deny CI job for `curve25519-dalek` timing attack and yanked `libc` version.

https://rustsec.org/advisories/RUSTSEC-2024-0344.html