### PR TITLE
Bring VM service more inline with other auraed services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,35 +204,35 @@ $(1)-lint: $(GEN_RS) $(GEN_TS)
 
 .PHONY: $(1)-test
 $(1)-test: $(GEN_RS) $(GEN_TS) auraed
-	$(cargo) test  -p $(1)
+	$(cargo) test  -p $(1) --locked
 
 .PHONY: $(1)-test-all
 $(1)-test-all: $(GEN_RS) $(GEN_TS) auraed
-	$(root_cargo) test  -p $(1) -- --include-ignored
+	$(root_cargo) test  -p $(1) --locked -- --include-ignored
 
 .PHONY: $(1)-test-integration
 $(1)-test-integration: $(GEN_RS) $(GEN_TS) auraed
-	$(root_cargo) test -p $(1) --test '*' -- --include-ignored
+	$(root_cargo) test -p $(1) --locked --test '*' -- --include-ignored
 
 .PHONY: $(1)-test-watch
 $(1)-test-watch: $(GEN_RS) $(GEN_TS) auraed # Use cargo-watch to continuously run a test (e.g. make $(1)-test-watch name=path::to::test)
-	$(root_cargo) watch -- $(cargo) test  -p $(1) $(name) -- --include-ignored --nocapture
+	$(root_cargo) watch -- $(cargo) test -p $(1) --locked $(name) -- --include-ignored --nocapture
 
 .PHONY: $(1)-build
 $(1)-build: $(GEN_RS) $(GEN_TS)
-	$(cargo) build  -p $(1)
+	$(cargo) build -p $(1) --locked
 
 .PHONY: $(1)-build-release
 $(1)-build-release: $(GEN_RS) $(GEN_TS)
-	$(cargo) build  -p $(1) --release
+	$(cargo) build -p $(1) --locked --release
 
 .PHONY: $(1)-debug
 $(1)-debug: $(GEN_RS) $(GEN_TS) $(1)-lint
-	$(cargo) install  --path ./$(1) --debug --force
+	$(cargo) install --path ./$(1) --debug --force --locked
 
 .PHONY: $(1)-release
 $(1)-release: $(GEN_RS) $(GEN_TS) $(1)-lint $(1)-test ## Lint, test, and install $(1)
-	$(cargo) install  --path ./$(1) --force
+	$(cargo) install --path ./$(1) --force --locked
 endef
 
 $(foreach p,$(PROGS),$(eval $(call AURAE_template,$(p),$(if $(findstring auraed,$(p)),))))
@@ -257,7 +257,7 @@ endif
 
 .PHONY: not-auraed-build
 not-auraed-build: $(GEN_RS) $(GEN_TS)
-	$(cargo) build --workspace --exclude auraed
+	$(cargo) build --workspace --locked --exclude auraed
 
 .PHONY: not-auraed-lint
 not-auraed-lint: $(GEN_RS) $(GEN_TS)
@@ -265,11 +265,11 @@ not-auraed-lint: $(GEN_RS) $(GEN_TS)
 
 .PHONY: not-auraed-test
 not-auraed-test: $(GEN_RS) $(GEN_TS)
-	$(cargo) test --workspace --exclude auraed
+	$(cargo) test --workspace --locked --exclude auraed
 
 .PHONY: not-auraed-test-all
 not-auraed-test-all: $(GEN_RS) $(GEN_TS)
-	$(cargo) test --workspace --exclude auraed -- --include-ignored
+	$(cargo) test --workspace --locked --exclude auraed -- --include-ignored
 
 #------------------------------------------------------------------------------#
 
@@ -281,11 +281,11 @@ libs-lint: $(GEN_RS) $(GEN_TS)
 
 .PHONY: libs-test
 libs-test: $(GEN_RS) $(GEN_TS)
-	$(cargo) test --workspace --exclude auraed --exclude auraescript --exclude aer
+	$(cargo) test --workspace --locked --exclude auraed --exclude auraescript --exclude aer
 
 .PHONY: libs-test-all
 libs-test-all: $(GEN_RS) $(GEN_TS)
-	$(cargo) test --workspace --exclude auraed --exclude auraescript --exclude aer -- --include-ignored
+	$(cargo) test --workspace --locked --exclude auraed --exclude auraescript --exclude aer -- --include-ignored
 
 .PHONY: ebpf
 ebpf:

--- a/api/v0/vms/vms.proto
+++ b/api/v0/vms/vms.proto
@@ -36,7 +36,7 @@ option go_package = "github.com/aurae-runtime/ae/client/pkg/api/v0/vms;vmsv0";
 
 service VmService {
   // Reserve requested system resources for a new VM.
-  rpc Create(VmServiceCreateRequest) returns (VmServiceCreateResponse) {}
+  rpc Allocate(VmServiceAllocateRequest) returns (VmServiceAllocateResponse) {}
 
   // Free up previously requested resources for an existing VM
   rpc Free(VmServiceFreeRequest) returns (VmServiceFreeResponse) {}
@@ -79,10 +79,10 @@ message VirtualMachineSummary {
   string auraed_address = 7;
 }
 
-message VmServiceCreateRequest{
+message VmServiceAllocateRequest{
   VirtualMachine machine = 1;
 }
-message VmServiceCreateResponse{
+message VmServiceAllocateResponse{
   string vm_id = 1;
 }
 

--- a/auraed/src/vms/error.rs
+++ b/auraed/src/vms/error.rs
@@ -13,10 +13,43 @@
  * SPDX-License-Identifier: Apache-2.0                                        *
 \* -------------------------------------------------------------------------- */
 
-mod error;
-mod manager;
-mod virtual_machine;
-mod virtual_machines;
-mod vm_service;
+use thiserror::Error;
+use tonic::Status;
+use tracing::error;
 
-pub(crate) use vm_service::VmService;
+use super::virtual_machine::VmID;
+
+pub(crate) type Result<T> = std::result::Result<T, VmServiceError>;
+
+#[derive(Debug, Error)]
+pub(crate) enum VmServiceError {
+    #[error("vm '{id}' could not be created: {source}")]
+    FailedToCreateError { id: VmID, source: anyhow::Error },
+    #[error("vm '{id}' could not be freed: {source}")]
+    FailedToFreeError { id: VmID, source: anyhow::Error },
+    #[error("vm '{id}' could not be started: {source}")]
+    FailedToStartError { id: VmID, source: anyhow::Error },
+    #[error("vm '{id}' could not be stopped: {source}")]
+    FailedToStopError { id: VmID, source: anyhow::Error },
+    #[error("vm config has no machine specified")]
+    MissingMachineConfig,
+    #[error("vm '{id}' config has no root drive specified")]
+    MissingRootDrive { id: VmID },
+}
+
+impl From<VmServiceError> for Status {
+    fn from(err: VmServiceError) -> Self {
+        let msg = err.to_string();
+        error!("{msg}");
+        match err {
+            VmServiceError::FailedToCreateError { .. }
+            | VmServiceError::FailedToFreeError { .. }
+            | VmServiceError::FailedToStartError { .. }
+            | VmServiceError::FailedToStopError { .. } => Status::internal(msg),
+            VmServiceError::MissingMachineConfig { .. }
+            | VmServiceError::MissingRootDrive { .. } => {
+                Status::failed_precondition(msg)
+            }
+        }
+    }
+}

--- a/auraed/src/vms/error.rs
+++ b/auraed/src/vms/error.rs
@@ -23,8 +23,8 @@ pub(crate) type Result<T> = std::result::Result<T, VmServiceError>;
 
 #[derive(Debug, Error)]
 pub(crate) enum VmServiceError {
-    #[error("vm '{id}' could not be created: {source}")]
-    FailedToCreateError { id: VmID, source: anyhow::Error },
+    #[error("vm '{id}' could not be allocated: {source}")]
+    FailedToAllocateError { id: VmID, source: anyhow::Error },
     #[error("vm '{id}' could not be freed: {source}")]
     FailedToFreeError { id: VmID, source: anyhow::Error },
     #[error("vm '{id}' could not be started: {source}")]
@@ -42,7 +42,7 @@ impl From<VmServiceError> for Status {
         let msg = err.to_string();
         error!("{msg}");
         match err {
-            VmServiceError::FailedToCreateError { .. }
+            VmServiceError::FailedToAllocateError { .. }
             | VmServiceError::FailedToFreeError { .. }
             | VmServiceError::FailedToStartError { .. }
             | VmServiceError::FailedToStopError { .. } => Status::internal(msg),

--- a/auraed/tests/vms_start_must_start_vm_with_auraed.rs
+++ b/auraed/tests/vms_start_must_start_vm_with_auraed.rs
@@ -19,7 +19,7 @@ use client::{Client, ClientError};
 use common::remote_auraed_client;
 use proto::discovery::DiscoverRequest;
 use proto::vms::{
-    RootDrive, VirtualMachine, VmServiceCreateRequest, VmServiceListRequest,
+    RootDrive, VirtualMachine, VmServiceAllocateRequest, VmServiceListRequest,
     VmServiceStartRequest,
 };
 
@@ -32,7 +32,7 @@ async fn vms_with_auraed() {
     let client = common::auraed_client().await;
     let res = retry!(
         client
-            .create(VmServiceCreateRequest {
+            .allocate(VmServiceAllocateRequest {
                 machine: Some(VirtualMachine {
                     id: vm_id.clone(),
                     mem_size_mb: 1024,


### PR DESCRIPTION
Specifically:
  * add a custom error enum and use it
  * split the basic implementation from the tonic wrapper
  * add basic documentation
  * rename create to allocate

TODO:
  * validate requests
  * add tests