### PR TITLE
chore(buf): Fix buf warning

### DIFF
--- a/api/buf.yaml
+++ b/api/buf.yaml
@@ -4,7 +4,7 @@ breaking:
     - FILE
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   ignore:
     - cri/v1/release-1.26.proto
     - grpc/health/v1/health.proto


### PR DESCRIPTION
Replace `DEFAULT` with `STANDARD` as recommended by the warning message when running `buf lint api`.

Message excerpt:
```
Category DEFAULT referenced in your buf.yaml is deprecated. It has been replaced by category STANDARD.

[...]

As with all buf changes, this change is backwards-compatible: DEFAULT will continue to work.
We recommend replacing DEFAULT in your buf.yaml, but no action is immediately necessary.
```