### PR TITLE
chore: Ensure lints cover tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ $(1): $(GEN_RS) $(GEN_TS) $(1)-lint $(1)-debug ## Lint and install $(1) (for use
 
 .PHONY: $(1)-lint
 $(1)-lint: fmt $(GEN_RS) $(GEN_TS)
-	$$(cargo) clippy $(2) -p $(1) --all-features -- -D clippy::all -D warnings
+	$$(cargo) clippy $(2) -p $(1) --all-features --all-targets -- -D clippy::all -D warnings
 
 .PHONY: $(1)-test
 $(1)-test: $(GEN_RS) $(GEN_TS) $(1)-lint auraed-debug

--- a/auraed/src/lib.rs
+++ b/auraed/src/lib.rs
@@ -368,8 +368,10 @@ mod tests {
         );
 
         let custom_runtime_dir = PathBuf::from("/tmp/aurae-test-runtime");
-        let mut runtime = AuraedRuntime::default();
-        runtime.runtime_dir = custom_runtime_dir.clone();
+        let runtime = AuraedRuntime {
+            runtime_dir: custom_runtime_dir.clone(),
+            ..Default::default()
+        };
         assert_eq!(
             runtime.default_socket_address(),
             custom_runtime_dir.join("aurae.sock")

--- a/auraed/tests/auraed_nested_should_run_cell_context.rs
+++ b/auraed/tests/auraed_nested_should_run_cell_context.rs
@@ -93,17 +93,17 @@ async fn wait_for_socket_and_connect(
 ) -> Channel {
     let deadline = tokio::time::Instant::now() + timeout;
     while tokio::time::Instant::now() < deadline {
-        if path.exists() {
-            if let Ok(channel) = connect_unix(path).await {
-                let meta = std::fs::symlink_metadata(path)
-                    .expect("metadata for socket");
-                assert!(
-                    meta.file_type().is_socket(),
-                    "expected {:?} to be a Unix socket",
-                    path
-                );
-                return channel;
-            }
+        if path.exists()
+            && let Ok(channel) = connect_unix(path).await
+        {
+            let meta =
+                std::fs::symlink_metadata(path).expect("metadata for socket");
+            assert!(
+                meta.file_type().is_socket(),
+                "expected {:?} to be a Unix socket",
+                path
+            );
+            return channel;
         }
         sleep(Duration::from_millis(100)).await;
     }

--- a/auraed/tests/auraed_spawn_client_tls.rs
+++ b/auraed/tests/auraed_spawn_client_tls.rs
@@ -149,10 +149,10 @@ async fn wait_for_listener(addr: SocketAddr, child: &mut Child) {
 }
 
 fn teardown_child(child: &mut Child) {
-    if let Err(e) = child.kill() {
-        if e.kind() != std::io::ErrorKind::InvalidInput {
-            panic!("failed to kill auraed child: {e}");
-        }
+    if let Err(e) = child.kill()
+        && e.kind() != std::io::ErrorKind::InvalidInput
+    {
+        panic!("failed to kill auraed child: {e}");
     }
     let _ = child.wait();
 }


### PR DESCRIPTION
Adds `--all-targets` to Clippy as our lint target wasn't covering tests. Fixes all failing lints in `auraed/tests/`.