### PR TITLE
refactor(ebpf): use `AsyncFd` in `PerfEventReader`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,6 @@ dependencies = [
  "object",
  "once_cell",
  "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]

--- a/auraed/Cargo.toml
+++ b/auraed/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/bin/main.rs"
 anyhow = { workspace = true }
 client = { workspace = true }
 aurae-ebpf-shared = { path = "../ebpf-shared" }
-aya = { version = "0.13.1", features = ["async_tokio"] }
+aya = { version = "0.13.1" }
 backoff = { version = "0.4.0", features = ["tokio"] }
 bytes = "1.2.1"
 clap = { workspace = true }


### PR DESCRIPTION
`AsyncPerfEventArray` and the accompanying `async_tokio` is removed in future versions of `aya`. This change refactors our `PerfBufferReader` to use an `AsyncFd` for async support to reduce friction in migrating to a future release.

https://github.com/aya-rs/aya/pull/1292