### PR TITLE
Exclude generated files from license header scripts

### DIFF
--- a/hack/file-definitions
+++ b/hack/file-definitions
@@ -33,16 +33,17 @@ SCRIPTS=$(find . \( \
   -iname '*.sh' -or \
   -iname '*.toml' \
     \) -not -path '*/ignore/*' \
+    -not -path '*/gen/*' \
     -not -path './hypervisor/*' \
     -not -path './target/*' )
 
 ### HACK Dir Scripts
-HACKSCRIPTS=$(find -s hack -type f -not \( \
+HACKSCRIPTS=$(find hack -type f -not \( \
   -name 'certgen.client.ext' -or \
   -name 'certgen.server.ext' -or \
   -name '.header.script' -or \
   -name '.header.source' \
-    \))
+    \) | sort)
 
 ### Define Sources
 SOURCES=$(find . \( \
@@ -51,6 +52,7 @@ SOURCES=$(find . \( \
   -iname '*.c' -or \
   -iname '*.h' \
     \) -not -path '*/ignore/*' \
+    -not -path '*/gen/*' \
     -not -path './hypervisor/*' \
     -not -path './target/*' )
 
@@ -58,6 +60,6 @@ SOURCES=$(find . \( \
 RUSTSOURCES=$(find . \( \
   -iname '*.rs' \
     \) -not -path '*/ignore/*' \
-    -not -path -'*/gen/*' \
-    -not -path './target/*' \
-    -not -path -'./hypervisor/*' )
+    -not -path '*/gen/*' \
+    -not -path './hypervisor/*' \
+    -not -path './target/*' )


### PR DESCRIPTION
Adds */gen/* path exclusions to SOURCES and SCRIPTS in hack/file-definitions so headers-write and headers-check ignore generated protobuf files.